### PR TITLE
Support cookies via new core hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The Descope SDK for React Native provides convenient access to Descope for an ap
 Install the package with:
 
 ```bash
+yarn add @descope/react-native-sdk
+# or
 npm i --save @descope/react-native-sdk
 ```
 

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     ]
   },
   "dependencies": {
-    "@descope/core-js-sdk": "^2.5.1",
+    "@descope/core-js-sdk": "2.15.1",
     "base-64": "^1.0.0"
   }
 }

--- a/src/internal/core/sdk.ts
+++ b/src/internal/core/sdk.ts
@@ -1,4 +1,5 @@
-import createCoreSdk from '@descope/core-js-sdk'
+import createCoreSdk, { type ExtendedResponse } from '@descope/core-js-sdk'
+import { Platform } from 'react-native'
 import { version } from '../../../package.json'
 
 export type Sdk = ReturnType<typeof createSdk>
@@ -6,8 +7,27 @@ export type SdkLogger = Parameters<typeof createCoreSdk>[0]['logger']
 export type SdkConfig = Parameters<typeof createCoreSdk>
 
 export const createSdk = (...config: SdkConfig) => {
-  config?.[0] && (config[0].baseHeaders = baseHeaders)
+  if (config[0]) {
+    // set base headers
+    config[0].baseHeaders = baseHeaders
+    // set parse cookie logic for iOS and Android
+    if (Platform.OS === 'ios' || Platform.OS === 'android') {
+      if (!config[0].hooks) config[0].hooks = {}
+      config[0].hooks.transformResponse = parseCookies
+    }
+  }
   return createCoreSdk(...config)
+}
+
+const parseCookies = async (mutableResponse: ExtendedResponse) => {
+  const resp = await mutableResponse.json()
+  if (mutableResponse.cookies.DS) {
+    resp.sessionJwt = mutableResponse.cookies.DS
+  }
+  if (mutableResponse.cookies.DSR) {
+    resp.refreshJwt = mutableResponse.cookies.DSR
+  }
+  return mutableResponse
 }
 
 const baseHeaders = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,13 +1186,12 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@descope/core-js-sdk@^2.5.1":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.10.0.tgz#d01eb12e8e9e9ad8c079c2c46e17ff4a94f69eb6"
-  integrity sha512-CzSRX9aVml4pEfBQrXfRlnDtALApjMawnKC7gDWRJ0stdRhokNSd5qIFF6z0FN/Y5pco/60PHmssaHAssVVs7g==
+"@descope/core-js-sdk@2.15.1":
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.15.1.tgz#726567dcbe21539b1028669396ffd9451a745fc4"
+  integrity sha512-IrqxrxLLRsOtq/q8KRrcNwAjzt4d8e45DVGVl3ri6TStVOmCbIZm6TUDF4cmvDBD5pqNUIHA+1kHOi+N4tCS4A==
   dependencies:
     jwt-decode "3.1.2"
-    lodash.get "4.4.2"
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -6296,11 +6295,6 @@ lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
-
-lodash.get@4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/6304

## Description

- Support cookies via new core hook when targeting iOS or Android.
- Pin core version

## Must

- [x] Tests
- [ ] Documentation (if applicable)
