### PR TITLE
Update core and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descope/react-native-sdk",
-  "version": "0.5.0-alpha.1",
+  "version": "0.6.0",
   "description": "The Descope SDK for React-Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -140,7 +140,7 @@
     ]
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.15.1",
+    "@descope/core-js-sdk": "2.17.0",
     "base-64": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@descope/core-js-sdk@2.15.1":
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.15.1.tgz#726567dcbe21539b1028669396ffd9451a745fc4"
-  integrity sha512-IrqxrxLLRsOtq/q8KRrcNwAjzt4d8e45DVGVl3ri6TStVOmCbIZm6TUDF4cmvDBD5pqNUIHA+1kHOi+N4tCS4A==
+"@descope/core-js-sdk@2.17.0":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.17.0.tgz#b075a42cf97badaa80e712c46818372092593bde"
+  integrity sha512-xBXbqZ2jAgmU7/qIMIzwREaGhZFccbfSC6orO3wqwWFZBhYIBJxcO5BV+dPg1HPsBhOGnanyuMhrolQ+7E+n/w==
   dependencies:
     jwt-decode "3.1.2"
 


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/6382

## Description

- Update core version to include password sign up options
- Bump version to 0.6.0
