### PR TITLE
Use yarn to build the project instead of npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,10 @@ jobs:
       # Skip post-install scripts here, as a malicious
       # script could steal NODE_AUTH_TOKEN.
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: yarn install --frozen-lockfile
         env:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.CI_NPM_READ_ORG }}
-      # `npm rebuild` will run all those post-install scripts for us.
-      - run: npm rebuild && npm run prepare --if-present
 
       - name: Publish to NPM Package Registry
         run: npm publish --access=public


### PR DESCRIPTION
## Description

Switching to `yarn` in our GH actions

