### PR TITLE
Update core and bump version for older RN compatibility

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
-  - descope-react-native (0.5.0-alpha.1):
+  - descope-react-native (0.6.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - DoubleConversion (1.1.6)
@@ -662,7 +662,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  descope-react-native: d0b759554b0680cac6b73d20662155e9ad1cfae0
+  descope-react-native: 4c3147e228c0e6099dbb507e08d81ac39acc0985
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descope/react-native-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The Descope SDK for React-Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -140,7 +140,7 @@
     ]
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.17.0",
+    "@descope/core-js-sdk": "2.20.4",
     "base-64": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@descope/core-js-sdk@2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.17.0.tgz#b075a42cf97badaa80e712c46818372092593bde"
-  integrity sha512-xBXbqZ2jAgmU7/qIMIzwREaGhZFccbfSC6orO3wqwWFZBhYIBJxcO5BV+dPg1HPsBhOGnanyuMhrolQ+7E+n/w==
+"@descope/core-js-sdk@2.20.4":
+  version "2.20.4"
+  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.20.4.tgz#443876890978e7355349edc81896a45366fae487"
+  integrity sha512-tib9cI4HorZUyVOqA9DPss7TzVebXCvQrExjRu7f4kMkWkfLmMJgqUuwuCqAnkHCoLrN4EEYeP7MZ6RK/UZ14Q==
   dependencies:
     jwt-decode "3.1.2"
 


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/6918

## Description

Update core version for older RN compatiblity

## Must

- [x] Tests
- [ ] Documentation (if applicable)
