### PR TITLE
Add useHostedFlowUrl hook to help construct hosted flow URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The `FlowOptions` defines all of the options available when running a flow on bo
 Android and iOS. Read the component documentation for a detailed explanation.
 
 ```js
-import { FlowView, useHostedFlowUrl } from '@descope/react-native-sdk'
+import { FlowView, useHostedFlowUrl, useSession } from '@descope/react-native-sdk'
 
 const { manageSession } = useSession()
 

--- a/README.md
+++ b/README.md
@@ -288,11 +288,13 @@ The `FlowOptions` defines all of the options available when running a flow on bo
 Android and iOS. Read the component documentation for a detailed explanation.
 
 ```js
-import { FlowView } from '@descope/react-native-sdk'
+import { FlowView, useHostedFlowUrl } from '@descope/react-native-sdk'
 
 const { manageSession } = useSession()
 
 const flowUrl = 'https://myflowUrl.com'
+// If using Descope hosted flows, you can provide the flow ID directly
+// const flowUrl = useHostedFlowUrl('<FLOW_ID_TO_RUN>')
 
 <FlowView
   style={styles.fill}

--- a/src/hooks/useHostedFlowUrl.ts
+++ b/src/hooks/useHostedFlowUrl.ts
@@ -1,0 +1,18 @@
+import useDescopeContext from '../internal/hooks/useContext'
+
+/**
+ * Creates a URL for a flow hosted on Descope's Flow hosting service.
+ *
+ * Note: This hook is only applicable when using Descope's Flow hosting service.
+ * If you host your own flows, construct the URL manually and pass it to FlowView instead.
+ *
+ * @param flowId The flow ID.
+ * @returns The URL for the hosted flow.
+ */
+export default function useHostedFlowUrl(flowId: string): string {
+  const { sdk, projectId } = useDescopeContext()
+  if (!sdk) {
+    throw new Error('useHostedFlowUrl must be used within a DescopeProvider')
+  }
+  return sdk.httpClient.buildUrl(`login/${projectId}`, { platform: 'mobile', wide: 'true', flow: flowId })
+}

--- a/src/hooks/useHostedFlowUrl.ts
+++ b/src/hooks/useHostedFlowUrl.ts
@@ -12,7 +12,7 @@ import useDescopeContext from '../internal/hooks/useContext'
 export default function useHostedFlowUrl(flowId: string): string {
   const { sdk, projectId } = useDescopeContext()
   if (!sdk) {
-    throw new Error('useHostedFlowUrl must be used within a DescopeProvider')
+    throw new Error('useHostedFlowUrl must be used within an <AuthProvider />')
   }
   return sdk.httpClient.buildUrl(`login/${projectId}`, { platform: 'mobile', wide: 'true', flow: flowId })
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ export { default as AuthProvider } from './components/AuthProvider'
 export { default as FlowView } from './components/FlowView'
 export { default as useDescope } from './hooks/useDescope'
 export { default as useSession } from './hooks/useSession'
+export { default as useHostedFlowUrl } from './hooks/useHostedFlowUrl'
 
 // deprecated
 export { default as useFlow } from './hooks/useFlow'

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -1,10 +1,52 @@
 import { renderHook } from '@testing-library/react-native'
-import { useFlow, useDescope, useSession } from '../src'
+import React from 'react'
+import { AuthProvider, useFlow, useDescope, useSession, useHostedFlowUrl } from '../src'
+import createCoreSdk from '@descope/core-js-sdk'
+
+jest.mock('@descope/core-js-sdk', () => jest.fn())
+
+jest.mock('../src/internal/modules/descopeModule', () => ({
+  __esModule: true,
+  default: {
+    loadItem: jest.fn().mockResolvedValue(null),
+    configureLogging: jest.fn().mockResolvedValue(null),
+  },
+}))
+
+const projectId = 'Ptest12aAc4T2V93bddihGEx2Ryhc8e5Z'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => React.createElement(AuthProvider, { projectId }, children)
 
 describe('hooks', () => {
   it('should not allow hooks to run outside AuthProvider', () => {
     expect(() => renderHook(useFlow)).toThrowError('You can only use this hook in the context of <AuthProvider />')
     expect(() => renderHook(useSession)).toThrowError('You can only use this hook in the context of <AuthProvider />')
     expect(() => renderHook(useDescope)).toThrowError('You can only use this hook in the context of <AuthProvider />')
+  })
+
+  describe('useHostedFlowUrl', () => {
+    const mockBuildUrl = jest.fn()
+
+    beforeEach(() => {
+      ;(createCoreSdk as unknown as jest.Mock).mockReturnValue({ httpClient: { buildUrl: mockBuildUrl } })
+    })
+
+    it('should throw when used outside AuthProvider', () => {
+      expect(() => renderHook(() => useHostedFlowUrl('sign-in'))).toThrowError('You can only use this hook in the context of <AuthProvider />')
+    })
+
+    it('should delegate URL building to the SDK httpClient', () => {
+      const expected = `https://api.test.descope.com/login/${projectId}?platform=mobile&wide=true&flow=sign-in`
+      mockBuildUrl.mockReturnValue(expected)
+
+      const { result } = renderHook(() => useHostedFlowUrl('sign-in'), { wrapper })
+
+      expect(mockBuildUrl).toHaveBeenCalledWith(`login/${projectId}`, {
+        platform: 'mobile',
+        wide: 'true',
+        flow: 'sign-in',
+      })
+      expect(result.current).toBe(expected)
+    })
   })
 })


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/13380

## Description

Add useHostedFlowUrl hook to help construct hosted flow URLs

## Must

- [x] Tests
- [x] Documentation (if applicable)
