### PR TITLE
fix(deps): bump @descope/core-js-sdk to 2.62.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-*gradle* @itaihanski @shilgapira @asafshen
-*.properties @itaihanski @shilgapira @asafshen
-package.json @itaihanski @shilgapira @asafshen
-/example/package.json @itaihanski @shilgapira @asafshen
-.nvmrc @itaihanski @shilgapira @asafshen
+*gradle* @itaihanski @shilgapira @asafshen @nirgur
+*.properties @itaihanski @shilgapira @asafshen @nirgur
+package.json @itaihanski @shilgapira @asafshen @nirgur
+/example/package.json @itaihanski @shilgapira @asafshen @nirgur
+.nvmrc @itaihanski @shilgapira @asafshen @nirgur

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.62.1",
+    "@descope/core-js-sdk": "2.62.2",
     "base-64": "1.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,12 +1672,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@descope/core-js-sdk@2.62.1":
-  version "2.62.1"
-  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.62.1.tgz#8638ab1e3bfb3fc7e9b0c614f0570d3e1484b0b0"
-  integrity sha512-Rs+CNjDyOQum0NCtXqspe04gdmXscva3kcNsYM74GOY9Rc5AU7OMHO14AZAm4U3Om7U2WusBxSyfTJPfjF49nA==
+"@descope/core-js-sdk@2.62.2":
+  version "2.62.2"
+  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.62.2.tgz#a90a01e28ac76a88fd09ae4ed838a125f1b4ef7d"
+  integrity sha512-BBG0s2tvXP86fsvgtE77Mbbr098d4N/KGlkrImHcdfzf5fdQbWn9lnFT4mpCMeRFM8d8s7LnLrn+570DZ75oSA==
   dependencies:
     jwt-decode "4.0.0"
+    tslib "2.8.1"
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -7248,6 +7249,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tslib@2.8.1, tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -7257,11 +7263,6 @@ tslib@^2.0.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tslib@^2.6.2:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16068 (completes the 2nd requirement; issue already closed by the 0.11.0 fix)

## Related PRs
### Related PRs
- descope/descope-js#1410 — core-js: declare `tslib` (released as 2.62.2)
- descope/descope-react-native#172 — previous bump (Metro fix, 0.11.0)

## In a Nutshell
- Bump `@descope/core-js-sdk` 2.62.1 → 2.62.2
- 2.62.2 declares `tslib`, so strict installers (bun/pnpm) no longer need a manual `bun add tslib`
- Also: add `@nirgur` to CODEOWNERS

## Description
core-js 2.62.2 declares `tslib` as a runtime dependency — it was used via TypeScript's `importHelpers` but never declared, so strict installers (bun, pnpm) couldn't resolve it and consumers had to add it by hand. This bump delivers that fix, completing the second of the two requirements from the customer report (the Metro async-arrow bundling fix shipped in 0.11.0).

Verified: `expo export` on Expo 56 / RN 0.85.3 resolves core-js 2.62.2 and bundles successfully.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)