### PR TITLE
chore: bump @descope/core-js-sdk to 2.67.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.62.2",
+    "@descope/core-js-sdk": "2.67.0",
     "base-64": "1.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,10 +1672,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@descope/core-js-sdk@2.62.2":
-  version "2.62.2"
-  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.62.2.tgz#a90a01e28ac76a88fd09ae4ed838a125f1b4ef7d"
-  integrity sha512-BBG0s2tvXP86fsvgtE77Mbbr098d4N/KGlkrImHcdfzf5fdQbWn9lnFT4mpCMeRFM8d8s7LnLrn+570DZ75oSA==
+"@descope/core-js-sdk@2.67.0":
+  version "2.67.0"
+  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.67.0.tgz#ddc550cadd3de3c4fb3fd934013a90eb3c3b1611"
+  integrity sha512-KOnmnhdePQ4JGNdy3sXH+YXWdo7bAbAjyg9NdkViS0E14MrOZDAXDPv6zP7T3akD2e6Q4KWOaG7dNurP8bCWiA==
   dependencies:
     jwt-decode "4.0.0"
     tslib "2.8.1"


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16830

## Description
- Bump `@descope/core-js-sdk` from `2.62.2` to `2.67.0`
- Picks up `externalToken` on `JWTResponse`, so flow exchange results expose the connector-minted token (parity with the native SDKs)

## Must
- [ ] Tests
- [ ] Documentation