### PR TITLE
feat: bump native SDKs and surface externalToken from flows

### DIFF
--- a/android/src/main/java/com/descope/Descope.kt
+++ b/android/src/main/java/com/descope/Descope.kt
@@ -3,6 +3,7 @@
 package com.descope
 
 import android.content.Context
+import android.net.Uri
 import com.descope.sdk.DescopeAuth
 import com.descope.sdk.DescopeConfig
 import com.descope.sdk.DescopeEnchantedLink
@@ -12,6 +13,7 @@ import com.descope.sdk.DescopeOAuth
 import com.descope.sdk.DescopeOtp
 import com.descope.sdk.DescopePasskey
 import com.descope.sdk.DescopePassword
+import com.descope.sdk.DescopePush
 import com.descope.sdk.DescopeSdk
 import com.descope.sdk.DescopeSso
 import com.descope.sdk.DescopeTotp
@@ -114,7 +116,36 @@ object Descope {
     /** Authentication with passwords. */
     val password: DescopePassword
         get() = sdk.password
-    
+
+    /** Authentication with push notifications. */
+    val push: DescopePush
+        get() = sdk.push
+
+    /**
+     * Resumes an ongoing authentication that's waiting for an external authentication step.
+     *
+     * When a flow performs authentication via Magic Link, OAuth, SSO, or external
+     * authentication at some point it will wait for the user to be redirected back to
+     * the app via a deep link. The host application is expected to intercept the deep
+     * link via App Links (or a custom scheme) and resume the running flow with it.
+     *
+     * You can do this by calling this function and passing the URI from the incoming
+     * intent. For example, from your Activity.onNewIntent:
+     *
+     *     override fun onNewIntent(intent: Intent) {
+     *         super.onNewIntent(intent)
+     *         intent.data?.let { Descope.handleUri(it) }
+     *     }
+     *
+     * - **Important**: This function must be called on the main thread, or it will throw
+     * a [com.descope.types.DescopeException.flowSetup] error.
+     *
+     * @param uri The URI to use for resuming the authentication.
+     * @return `true` when an ongoing authentication handled the URI or `false` to
+     *   let the caller know that the function didn't handle it.
+     */
+    fun handleUri(uri: Uri): Boolean = sdk.handleUri(uri)
+
     // The underlying `DescopeSdk` object used by the `Descope` singleton.
     internal lateinit var sdk: DescopeSdk
     

--- a/android/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlow.kt
@@ -80,7 +80,7 @@ class DescopeFlow {
     var oauthNativeProvider: OAuthProvider? = null
 
     /**
-     * An optional deep link link URL to use when performing OAuth authentication, overriding
+     * An optional deep link URL to use when performing OAuth authentication, overriding
      * whatever is configured in the flow or project.
      * - **IMPORTANT NOTE**: even though App Links are the recommended way to configure
      * deep links, some browsers, such as Opera, do not respect them and open the URLs inline.
@@ -99,7 +99,7 @@ class DescopeFlow {
     var oauthRedirectCustomScheme: String? = null
 
     /**
-     * An optional deep link link URL to use performing SSO authentication, overriding
+     * An optional deep link URL to use when performing SSO authentication, overriding
      * whatever is configured in the flow or project
      * - **IMPORTANT NOTE**: even though App Links are the recommended way to configure
      * deep links, some browsers, such as Opera, do not respect them and open the URLs inline.
@@ -118,7 +118,26 @@ class DescopeFlow {
     var ssoRedirectCustomScheme: String? = null
 
     /**
-     * An optional deep link link URL to use when sending magic link emails, overriding
+     * An optional deep link URL to use when performing external authentication, overriding
+     * whatever is configured in the flow or project.
+     * - **IMPORTANT NOTE**: even though App Links are the recommended way to configure
+     * deep links, some browsers, such as Opera, do not respect them and open the URLs inline.
+     * It is possible to circumvent this issue by providing a custom scheme via [externalAuthRedirectCustomScheme]
+     */
+    var externalAuthRedirect: String? = null
+
+    /**
+     * An optional custom scheme based URL, e.g. `mycustomscheme://myhost`,
+     * to use when performing external authentication overriding whatever is configured in the flow or project.
+     * Functionally, this URL is exactly the same as [externalAuthRedirect], and will be used in its stead, only
+     * when the user has a default browser that does not honor App Links by default.
+     * That means the `https` based App Links are opened inline in the browser, instead
+     * of being handled by the application.
+     */
+    var externalAuthRedirectCustomScheme: String? = null
+
+    /**
+     * An optional deep link URL to use when sending magic link emails, overriding
      * whatever is configured in the flow or project
      */
     var magicLinkRedirect: String? = null

--- a/android/src/main/java/com/descope/android/DescopeFlowBridge.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlowBridge.kt
@@ -19,6 +19,7 @@ import com.descope.internal.others.debug
 import com.descope.internal.others.error
 import com.descope.internal.others.info
 import com.descope.internal.others.isUnsafeEnabled
+import com.descope.internal.others.parseServerError
 import com.descope.internal.others.stringOrEmptyAsNull
 import com.descope.internal.others.with
 import com.descope.internal.routes.isWebAuthnSupported
@@ -103,8 +104,15 @@ internal class FlowBridge(val webView: WebView) {
     }
 
     private fun bridgeOnError(error: String) {
+        val parsed = parseServerError(error)
+        val exception = when {
+            parsed == null -> DescopeException.flowFailed.with(message = error)
+            // Convert server flow cancellation to local flow cancellation for cohesive error handling
+            parsed.code == "E102122" -> DescopeException.flowCancelled.with(message = parsed.message)
+            else -> parsed
+        }
         handler.post {
-            listener?.onError(DescopeException.flowFailed.with(message = error))
+            listener?.onError(exception)
         }
     }
 
@@ -305,16 +313,14 @@ internal data class FlowBridgeAttributes(
 
 internal sealed class FlowBridgeRequest {
     class OAuthNative(val start: JSONObject) : FlowBridgeRequest()
-    class OAuthWeb(val startUrl: String) : FlowBridgeRequest()
-    class Sso(val startUrl: String) : FlowBridgeRequest()
+    class WebAuth(val variant: String, val startUrl: String) : FlowBridgeRequest()
     class WebAuthnCreate(val transactionId: String, val options: String) : FlowBridgeRequest()
     class WebAuthnGet(val transactionId: String, val options: String) : FlowBridgeRequest()
 
     val type
         get() = when (this) {
             is OAuthNative -> "oauthNative"
-            is OAuthWeb -> "oauthWeb"
-            is Sso -> "sso"
+            is WebAuth -> variant
             is WebAuthnCreate -> "webauthnCreate"
             is WebAuthnGet -> "webauthnGet"
         }
@@ -326,8 +332,7 @@ internal sealed class FlowBridgeRequest {
             return json.getJSONObject("payload").run {
                 when (type) {
                     "oauthNative" -> OAuthNative(start = getJSONObject("start"))
-                    "oauthWeb" -> OAuthWeb(startUrl = getString("startUrl"))
-                    "sso" -> Sso(startUrl = getString("startUrl"))
+                    "oauthWeb", "sso", "externalAuth" -> WebAuth(variant = type, startUrl = getString("startUrl"))
                     "webauthnCreate" -> WebAuthnCreate(transactionId = getString("transactionId"), options = getString("options"))
                     "webauthnGet" -> WebAuthnGet(transactionId = getString("transactionId"), options = getString("options"))
                     else -> throw DescopeException.flowFailed.with(message = "Unexpected server response in flow")
@@ -340,16 +345,14 @@ internal sealed class FlowBridgeRequest {
 internal sealed class FlowBridgeResponse {
     class OAuthNative(val stateId: String, val identityToken: String) : FlowBridgeResponse()
     class WebAuthn(val type: String, val transactionId: String, val response: String) : FlowBridgeResponse()
-    class WebAuth(val type: String, val url: String) : FlowBridgeResponse()
-    class MagicLink(val url: String) : FlowBridgeResponse()
+    class DeepLink(val type: String, val url: String) : FlowBridgeResponse()
     class Failure(val failure: String) : FlowBridgeResponse()
 
     val typeName: String
         get() = when (this) {
             is OAuthNative -> "oauthNative"
             is WebAuthn -> type
-            is WebAuth -> type
-            is MagicLink -> "magicLink"
+            is DeepLink -> type
             is Failure -> "failure"
         }
 
@@ -365,8 +368,7 @@ internal sealed class FlowBridgeResponse {
                 put("transactionId", transactionId)
                 put("response", response)
             }.toString()
-            is WebAuth -> JSONObject().apply { put("url", url) }.toString()
-            is MagicLink -> JSONObject().apply { put("url", url) }.toString()
+            is DeepLink -> JSONObject().apply { put("url", url) }.toString()
             is Failure -> JSONObject().apply { put("failure", failure) }.toString()
         }
 }

--- a/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -62,6 +62,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
 
     private val bridge = FlowBridge(webView)
     private var flow: DescopeFlow? = null
+    private var pendingDeepLinkType: String? = null
     private val handler: Handler = Handler(Looper.getMainLooper())
     private val sdk: DescopeSdk?
         get() = flow?.sdk ?: if (Descope.isInitialized) Descope.sdk else null
@@ -98,23 +99,25 @@ class DescopeFlowCoordinator(val webView: WebView) {
         this.flow = flow
         bridge.flow = flow
         bridge.logger = logger
+        sdk?.resume = createResumeClosure(WeakReference(this))
         handleStarted()
         bridge.start()
     }
 
-    internal fun resumeFromDeepLink(deepLink: Uri) {
-        if (flow == null) {
-            logger.error("resumeFromDeepLink cannot be called before startFlow")
-            return
+    internal fun resumeFromDeepLink(deepLink: Uri): Boolean {
+        if (state != Started && state != Ready) {
+            logger.debug("Ignoring resume URL", state)
+            return false
         }
         activityHelper.closeCustomTab(webView.context)
-        val type = if (deepLink.queryParameterNames.contains("t")) "magicLink" else "oauthWeb"
-        val response = if (type == "magicLink") {
-            FlowBridgeResponse.MagicLink(url = deepLink.toString())
-        } else {
-            FlowBridgeResponse.WebAuth(type = type, url = deepLink.toString())
+        // magic links don't go through the bridge as a request, so detect them from the URL itself
+        val type = when {
+            deepLink.queryParameterNames.contains("t") -> "magicLink"
+            else -> pendingDeepLinkType ?: "oauthWeb"
         }
-        sendResponse(response)
+        pendingDeepLinkType = null
+        sendResponse(FlowBridgeResponse.DeepLink(type = type, url = deepLink.toString()))
+        return true
     }
 
     // Bridge Events
@@ -167,6 +170,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         val oauthProvider = flow.oauthNativeProvider?.name ?: ""
         val oauthRedirect = pickRedirectUrl(flow.oauthRedirect, flow.oauthRedirectCustomScheme, useCustomSchemeFallback)
         val ssoRedirect = pickRedirectUrl(flow.ssoRedirect, flow.ssoRedirectCustomScheme, useCustomSchemeFallback)
+        val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
         val nativeOptions = JSONObject().apply {
@@ -175,6 +179,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
             put("oauthProvider", oauthProvider)
             put("oauthRedirect", oauthRedirect)
             put("ssoRedirect", ssoRedirect)
+            put("externalAuthRedirect", externalAuthRedirect)
             put("magicLinkRedirect", magicLinkRedirect)
             put("origin", origin)
         }
@@ -279,8 +284,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         scope.launch(Dispatchers.Main) {
             when (request) {
                 is FlowBridgeRequest.OAuthNative -> handleOAuthNative(request)
-                is FlowBridgeRequest.OAuthWeb -> handleOAuthWeb(request)
-                is FlowBridgeRequest.Sso -> handleSso(request)
+                is FlowBridgeRequest.WebAuth -> handleWebAuth(request)
                 is FlowBridgeRequest.WebAuthnCreate -> handleWebAuthnCreate(request)
                 is FlowBridgeRequest.WebAuthnGet -> handleWebAuthnGet(request)
             }
@@ -295,6 +299,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         } catch (e: DescopeException) {
             if (e == DescopeException.oauthNativeCancelled) {
                 logger.info("OAuth native canceled")
+                sendResponse(FlowBridgeResponse.Failure("OAuthNativeCancelled"))
                 return
             }
             logger.error("OAuth native failed", e)
@@ -302,22 +307,18 @@ class DescopeFlowCoordinator(val webView: WebView) {
         }
     }
 
-    private fun handleOAuthWeb(request: FlowBridgeRequest.OAuthWeb) {
-        logger.info("Launching custom tab for web-based oauth")
+    private fun handleWebAuth(request: FlowBridgeRequest.WebAuth) {
+        pendingDeepLinkType = request.variant
+        logger.info("Launching custom tab for ${request.variant}")
         try {
-            launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
+            launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context)) {
+                // Custom tab dismissed by the user before completing the auth flow.
+                pendingDeepLinkType = null
+                sendResponse(FlowBridgeResponse.Failure("WebAuthCancelled"))
+            }
         } catch (e: DescopeException) {
             logger.error("Failed to launch custom tab", e)
-            sendResponse(FlowBridgeResponse.Failure("CustomTabFailure"))
-        }
-    }
-
-    private fun handleSso(request: FlowBridgeRequest.Sso) {
-        logger.info("Launching custom tab for sso")
-        try {
-            launchCustomTab(webView.context, request.startUrl, flow?.presentation?.createCustomTabsIntent(webView.context))
-        } catch (e: DescopeException) {
-            logger.error("Failed to launch custom tab", e)
+            pendingDeepLinkType = null
             sendResponse(FlowBridgeResponse.Failure("CustomTabFailure"))
         }
     }
@@ -330,6 +331,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         } catch (e: DescopeException) {
             if (e == DescopeException.passkeyCancelled) {
                 logger.info("Passkeys canceled")
+                sendResponse(FlowBridgeResponse.Failure("PasskeyCancelled"))
                 return
             }
             val failure = when (e) {
@@ -358,6 +360,7 @@ class DescopeFlowCoordinator(val webView: WebView) {
         } catch (e: DescopeException) {
             if (e == DescopeException.passkeyCancelled) {
                 logger.info("Passkeys canceled")
+                sendResponse(FlowBridgeResponse.Failure("PasskeyCancelled"))
                 return
             }
             val failure = when (e) {
@@ -456,4 +459,8 @@ private fun createTimerAction(ref: WeakReference<DescopeFlowCoordinator>): (Time
             coordinator.periodicRefreshJwtUpdate()
         }
     }
+}
+
+private fun createResumeClosure(ref: WeakReference<DescopeFlowCoordinator>): (Uri) -> Boolean {
+    return { uri -> ref.get()?.resumeFromDeepLink(uri) ?: false }
 }

--- a/android/src/main/java/com/descope/android/DescopeFlowView.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlowView.kt
@@ -145,13 +145,14 @@ class DescopeFlowView : ViewGroup {
     
     /**
      * Resume an already running flow after a deep link
-     * event. This function should be called to complete `Magic Link`
-     * and web-based `OAuth` authentication.
+     * event. This function should be called to complete `Magic Link`,
+     * web-based `OAuth`, `SSO`, and external authentication.
      *
      * @param deepLink The incoming deep link URI
+     * @return `true` if the running flow consumed the URI, `false` otherwise.
      */
-    fun resumeFromDeepLink(deepLink: Uri) {
-        flowCoordinator.resumeFromDeepLink(deepLink)
+    fun resumeFromDeepLink(deepLink: Uri): Boolean {
+        return flowCoordinator.resumeFromDeepLink(deepLink)
     }
 
     // Internal 

--- a/android/src/main/java/com/descope/android/DescopeHelperActivity.kt
+++ b/android/src/main/java/com/descope/android/DescopeHelperActivity.kt
@@ -30,6 +30,7 @@ class DescopeHelperActivity : Activity() {
         // interfere with user input, etc.
         if (listenForClose) {
             listenForClose = false
+            activityHelper.onCustomTabCanceled()
             finish()
         } else {
             listenForClose = true

--- a/android/src/main/java/com/descope/android/Utils.kt
+++ b/android/src/main/java/com/descope/android/Utils.kt
@@ -27,12 +27,12 @@ fun sendViewIntent(context: Context, uri: Uri) {
 
 // Custom Tab
 
-fun launchCustomTab(context: Context, url: String, customTabsIntent: CustomTabsIntent? = null) {
-    launchCustomTab(context, url.toUri(), customTabsIntent)
+fun launchCustomTab(context: Context, url: String, customTabsIntent: CustomTabsIntent? = null, onCancel: (() -> Unit)? = null) {
+    launchCustomTab(context, url.toUri(), customTabsIntent, onCancel)
 }
 
-fun launchCustomTab(context: Context, uri: Uri, customTabsIntent: CustomTabsIntent? = null) {
-    activityHelper.openCustomTab(context, customTabsIntent ?: defaultCustomTabIntent(), uri)
+fun launchCustomTab(context: Context, uri: Uri, customTabsIntent: CustomTabsIntent? = null, onCancel: (() -> Unit)? = null) {
+    activityHelper.openCustomTab(context, customTabsIntent ?: defaultCustomTabIntent(), uri, onCancel)
 }
 
 internal fun defaultCustomTabIntent(): CustomTabsIntent {

--- a/android/src/main/java/com/descope/internal/http/ClientErrors.kt
+++ b/android/src/main/java/com/descope/internal/http/ClientErrors.kt
@@ -1,21 +1,7 @@
 package com.descope.internal.http
 
-import com.descope.internal.others.toMap
 import com.descope.internal.others.with
 import com.descope.types.DescopeException
-import org.json.JSONObject
-
-internal fun parseServerError(response: String): DescopeException? {
-    try {
-        val map = JSONObject(response).toMap()
-        val code = map["errorCode"] as? String ?: return null
-        val desc = map["errorDescription"] as? String ?: "Descope server error"
-        val message = map["errorMessage"] as? String
-        return DescopeException(code = code, desc = desc, message = message)
-    } catch (_: Exception) {
-        return null
-    }
-}
 
 internal fun exceptionFromResponseCode(code: Int): DescopeException? {
     val desc = failureFromResponseCode(code) ?: return null

--- a/android/src/main/java/com/descope/internal/http/DescopeClient.kt
+++ b/android/src/main/java/com/descope/internal/http/DescopeClient.kt
@@ -1,6 +1,7 @@
 package com.descope.internal.http
 
 import com.descope.android.SystemInfo
+import com.descope.internal.others.parseServerError
 import com.descope.sdk.DescopeConfig
 import com.descope.sdk.DescopeSdk
 import com.descope.types.DeliveryMethod
@@ -14,7 +15,7 @@ import com.descope.types.SignUpDetails
 import com.descope.types.UpdateOptions
 import java.net.HttpCookie
 
-internal open class DescopeClient(internal val config: DescopeConfig, systemInfo: SystemInfo) : HttpClient(config.baseUrl ?: baseUrlForProjectId(config.projectId), config.logger, config.networkClient) {
+internal open class DescopeClient(internal val config: DescopeConfig, internal val systemInfo: SystemInfo) : HttpClient(config.baseUrl ?: baseUrlForProjectId(config.projectId), config.logger, config.networkClient) {
 
     // OTP
 
@@ -457,6 +458,29 @@ internal open class DescopeClient(internal val config: DescopeConfig, systemInfo
         body = mapOf(
             "flowId" to flowId,
             "codeChallenge" to codeChallenge,
+        ),
+    )
+
+    // Push
+
+    suspend fun pushEnrollDevice(token: String, device: String, refreshJwt: String): Unit = post(
+        route = "auth/push/update",
+        decoder = emptyResponse,
+        headers = authorization(refreshJwt),
+        body = mapOf(
+            "provider" to "fcm",
+            "token" to token,
+            "device" to device,
+        ),
+    )
+
+    suspend fun pushSignInFinish(transactionId: String, approved: Boolean, refreshJwt: String): Unit = post(
+        route = "auth/push/signin/finish",
+        decoder = emptyResponse,
+        headers = authorization(refreshJwt),
+        body = mapOf(
+            "transactionId" to transactionId,
+            "result" to if (approved) "approved" else "denied",
         ),
     )
 

--- a/android/src/main/java/com/descope/internal/http/Responses.kt
+++ b/android/src/main/java/com/descope/internal/http/Responses.kt
@@ -21,6 +21,7 @@ internal data class JwtServerResponse(
     val cookiePath: String,
     val cookieName: String?,
     val sessionCookieName: String?,
+    val externalToken: String?,
 ) {
     companion object {
         fun fromJson(json: String, cookies: List<HttpCookie>) = JSONObject(json).run {
@@ -49,6 +50,7 @@ internal data class JwtServerResponse(
                 cookiePath = stringOrEmptyAsNull("cookiePath") ?: "",
                 cookieName = cookieName,
                 sessionCookieName = sessionCookieName,
+                externalToken = stringOrEmptyAsNull("externalToken"),
             )
         }
     }

--- a/android/src/main/java/com/descope/internal/others/ActivityHelper.kt
+++ b/android/src/main/java/com/descope/internal/others/ActivityHelper.kt
@@ -10,14 +10,18 @@ import com.descope.types.DescopeException
 
 internal interface ActivityHelper {
     val customTabsIntent: CustomTabsIntent?
-    fun openCustomTab(context: Context, customTabsIntent: CustomTabsIntent, url: Uri)
+    // onCancel is registered JIT (lifecycle-bound to this custom-tab launch) so
+    // it doesn't outlive the tab and can't be hijacked by a different caller.
+    fun openCustomTab(context: Context, customTabsIntent: CustomTabsIntent, url: Uri, onCancel: (() -> Unit)? = null)
     fun closeCustomTab(context: Context)
+    fun onCustomTabCanceled()
 }
 
 internal val activityHelper = object : ActivityHelper {
+    private var cancelCallback: (() -> Unit)? = null
     override var customTabsIntent: CustomTabsIntent? = null
 
-    override fun openCustomTab(context: Context, customTabsIntent: CustomTabsIntent, url: Uri) {
+    override fun openCustomTab(context: Context, customTabsIntent: CustomTabsIntent, url: Uri, onCancel: (() -> Unit)?) {
         this.customTabsIntent = customTabsIntent
         if (!isBrowserSupported(context, url)) {
             throw DescopeException.customTabFailed.with(message = "No browser application was found")
@@ -30,11 +34,13 @@ internal val activityHelper = object : ActivityHelper {
         } catch (e: Exception) {
             throw DescopeException.customTabFailed.with(message = "Failed to open custom tab from context", cause = e)
         }
+        this.cancelCallback = onCancel
     }
 
     override fun closeCustomTab(context: Context) {
         if (this.customTabsIntent == null) return
         this.customTabsIntent = null
+        this.cancelCallback = null
         val intent = Intent(context, DescopeHelperActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         try {
@@ -42,6 +48,11 @@ internal val activityHelper = object : ActivityHelper {
         } catch (e: Exception) {
             throw DescopeException.customTabFailed.with(message = "Failed to close custom tab from context", cause = e)
         }
+    }
+
+    override fun onCustomTabCanceled() {
+        cancelCallback?.invoke()
+        cancelCallback = null
     }
 
     private fun isBrowserSupported(context: Context, uri: Uri): Boolean {

--- a/android/src/main/java/com/descope/internal/others/Errors.kt
+++ b/android/src/main/java/com/descope/internal/others/Errors.kt
@@ -1,6 +1,7 @@
 package com.descope.internal.others
 
 import com.descope.types.DescopeException
+import org.json.JSONObject
 
 internal fun DescopeException.with(desc: String? = null, message: String? = null, cause: Throwable? = null) = DescopeException(
     code = code,
@@ -8,3 +9,15 @@ internal fun DescopeException.with(desc: String? = null, message: String? = null
     message = message ?: this.message,
     cause = cause ?: this.cause,
 )
+
+internal fun parseServerError(response: String): DescopeException? {
+    try {
+        val map = JSONObject(response).toMap()
+        val code = map["errorCode"] as? String ?: return null
+        val desc = map["errorDescription"] as? String ?: "Descope server error"
+        val message = map["errorMessage"] as? String
+        return DescopeException(code = code, desc = desc, message = message)
+    } catch (_: Exception) {
+        return null
+    }
+}

--- a/android/src/main/java/com/descope/internal/routes/Push.kt
+++ b/android/src/main/java/com/descope/internal/routes/Push.kt
@@ -1,0 +1,15 @@
+package com.descope.internal.routes
+
+import com.descope.internal.http.DescopeClient
+import com.descope.sdk.DescopePush
+
+internal class Push(private val client: DescopeClient) : DescopePush {
+
+    override suspend fun enroll(token: String, refreshJwt: String) {
+        client.pushEnrollDevice(token = token, device = client.systemInfo.device ?: "Android", refreshJwt = refreshJwt)
+    }
+
+    override suspend fun finish(transactionId: String, approved: Boolean, refreshJwt: String) {
+        client.pushSignInFinish(transactionId = transactionId, approved = approved, refreshJwt = refreshJwt)
+    }
+}

--- a/android/src/main/java/com/descope/internal/routes/Shared.kt
+++ b/android/src/main/java/com/descope/internal/routes/Shared.kt
@@ -61,6 +61,7 @@ internal fun JwtServerResponse.convert(): AuthenticationResponse {
         sessionToken = Token(sessionJwt),
         user = user.convert(),
         isFirstAuthentication = firstSeen,
+        externalToken = externalToken,
     )
 }
 

--- a/android/src/main/java/com/descope/sdk/Routes.kt
+++ b/android/src/main/java/com/descope/sdk/Routes.kt
@@ -956,3 +956,32 @@ interface DescopeFlow {
      */
     data class Authentication(val flowId: String, val refreshJwt: String)
 }
+
+/**
+ * Authenticate users using push notifications.
+ *
+ * The push notification authentication works by registering the user's device
+ * via FCM (Firebase Cloud Messaging) and then completing authentication
+ * transactions by approving or denying them.
+ */
+interface DescopePush {
+    /**
+     * Registers an FCM device token for push authentication.
+     *
+     * The user must have an active [DescopeSession] whose [refreshJwt] should be
+     * passed as a parameter to this function.
+     *
+     * @param token the FCM device token to register.
+     * @param refreshJwt the refreshJwt from an active [DescopeSession].
+     */
+    suspend fun enroll(token: String, refreshJwt: String)
+
+    /**
+     * Completes a push authentication transaction by approving or denying it.
+     *
+     * @param transactionId the ID of the push authentication transaction.
+     * @param approved whether the authentication request is approved or denied.
+     * @param refreshJwt the refreshJwt from an active [DescopeSession].
+     */
+    suspend fun finish(transactionId: String, approved: Boolean, refreshJwt: String)
+}

--- a/android/src/main/java/com/descope/sdk/Sdk.kt
+++ b/android/src/main/java/com/descope/sdk/Sdk.kt
@@ -4,6 +4,7 @@ package com.descope.sdk
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.net.Uri
 import android.os.Looper
 import com.descope.android.DescopeSystemInfo
 import com.descope.internal.http.DescopeClient
@@ -16,11 +17,14 @@ import com.descope.internal.routes.OAuth
 import com.descope.internal.routes.Otp
 import com.descope.internal.routes.Passkey
 import com.descope.internal.routes.Password
+import com.descope.internal.routes.Push
 import com.descope.internal.routes.Sso
 import com.descope.internal.routes.Totp
+import com.descope.internal.others.with
 import com.descope.session.DescopeSessionManager
 import com.descope.session.SessionLifecycle
 import com.descope.session.SessionStorage
+import com.descope.types.DescopeException
 
 class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.() -> Unit) {
     var sessionManager: DescopeSessionManager
@@ -33,6 +37,7 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
     val sso: DescopeSso
     val passkey: DescopePasskey
     val password: DescopePassword
+    val push: DescopePush
     @Deprecated(message = "Use DescopeFlowView instead")
     val flow: DescopeFlow
 
@@ -59,12 +64,32 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         sso = Sso(client)
         passkey = Passkey(client)
         password = Password(client)
+        push = Push(client)
         flow = Flow(client)
         // init session manager
         sessionManager = initDefaultManager(context, config)
     }
 
+    /**
+     * Resumes an ongoing authentication that's waiting for an external authentication step.
+     *
+     * - **Important**: This function must be called on the main thread, or it will throw
+     * a [DescopeException.flowSetup] error.
+     */
+    fun handleUri(uri: Uri): Boolean {
+        if (Looper.getMainLooper().thread != Thread.currentThread()) {
+            throw DescopeException.flowSetup.with(message = "Descope.handleUri must be called on the main thread")
+        }
+        return resume(uri)
+    }
+
     // Internal
+
+    /**
+     * While the flow is running this is set to a closure with a weak reference to
+     * the [DescopeFlowCoordinator] to provide it with the resume URI.
+     */
+    internal var resume: (Uri) -> Boolean = { false }
 
     private fun initDefaultManager(context: Context, config: DescopeConfig): DescopeSessionManager {
         val storage = SessionStorage(context.applicationContext, config.projectId, config.logger)
@@ -79,6 +104,6 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         const val NAME = "DescopeAndroid"
 
         /** The Descope SDK version */
-        const val VERSION = "0.18.2"
+        const val VERSION = "0.19.1" // x-release-please-version
     }
 }

--- a/android/src/main/java/com/descope/types/Responses.kt
+++ b/android/src/main/java/com/descope/types/Responses.kt
@@ -9,12 +9,14 @@ import com.descope.session.DescopeToken
  * @property refreshToken the refresh token is used to refresh expired session tokens.
  * @property isFirstAuthentication whether this the user's first authentication.
  * @property user information about the user.
+ * @property externalToken a token provided by an external token connector, when configured in the project.
  */
 data class AuthenticationResponse(
     val sessionToken: DescopeToken,
     val refreshToken: DescopeToken,
     val isFirstAuthentication: Boolean,
     val user: DescopeUser,
+    val externalToken: String? = null,
 )
 
 /**

--- a/android/src/main/java/com/descopereactnative/DescopeFlowViewManager.kt
+++ b/android/src/main/java/com/descopereactnative/DescopeFlowViewManager.kt
@@ -195,8 +195,8 @@ private fun AuthenticationResponse.toJsonString(): String {
     put("refreshJwt", refreshToken.jwt)
     put("user", user.toJson())
     put("firstSeen", isFirstAuthentication)
+    externalToken?.run { put("externalToken", this) }
   }
-  println(json.toString(2))
   return json.toString()
 }
 

--- a/ios/descope-swift-sdk/DescopeKit.swift
+++ b/ios/descope-swift-sdk/DescopeKit.swift
@@ -92,6 +92,9 @@ public extension Descope {
     /// Provides functions for authentication with enchanted links.
     static var enchantedLink: DescopeEnchantedLink { sdk.enchantedLink }
     
+    /// Provides functions for authentication with push notifications.
+    static var push: DescopePush { sdk.push }
+    
     /// Provides functions for authentication with OAuth.
     static var oauth: DescopeOAuth { sdk.oauth }
     

--- a/ios/descope-swift-sdk/flows/FlowBridge.swift
+++ b/ios/descope-swift-sdk/flows/FlowBridge.swift
@@ -224,7 +224,10 @@ extension FlowBridge {
             }
         case .failure:
             logger.error("Bridge received failure event", message.body)
-            if let dict = message.body as? [String: Any], let error = DescopeError(errorResponse: dict) {
+            if let dict = message.body as? [String: Any], var error = DescopeError(errorResponse: dict) {
+                if error.code == "E102122" { // convert server-side flow aborted error to client-side flow cancelled error
+                    error = DescopeError.flowCancelled.with(message: error.message)
+                }
                 delegate?.bridgeDidFailAuthentication(self, error: error)
             } else if let reason = message.body as? String, !reason.isEmpty {
                 delegate?.bridgeDidFailAuthentication(self, error: DescopeError.flowFailed.with(message: reason))
@@ -286,7 +289,7 @@ extension FlowBridge: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation, withError error: Error) {
-        var error = error as NSError
+        let error = error as NSError
         
         // Ignore navigation cancellations that are an expected part of the navigation lifecycle
         // due to, e.g., redirects,
@@ -367,7 +370,7 @@ private extension FlowBridgeRequest {
             guard let start = payload["start"] as? [String: Any] else { return nil }
             guard let clientId = start["clientId"] as? String, let stateId = start["stateId"] as? String, let nonce = start["nonce"] as? String, let implicit = start["implicit"] as? Bool else { return nil }
             self = .oauthNative(clientId: clientId, stateId: stateId, nonce: nonce, implicit: implicit)
-        case "oauthWeb", "sso":
+        case "oauthWeb", "sso", "externalAuth":
             guard let startString = payload["startUrl"] as? String, let startURL = URL(string: startString) else { return nil }
             var finishURL: URL?
             if let str = payload["finishUrl"] as? String, !str.isEmpty, let url = URL(string: str) {
@@ -446,6 +449,7 @@ private struct FlowNativeOptions: Encodable {
     var oauthProvider = ""
     var oauthRedirect = WebAuth.redirectURL
     var ssoRedirect = WebAuth.redirectURL
+    var externalAuthRedirect = WebAuth.redirectURL
     var magicLinkRedirect = ""
 
     var payload: String {
@@ -501,7 +505,7 @@ window.descopeBridge = {
         platformVersion: \(SystemInfo.osVersion.javaScriptLiteralString()),
         appName: \(SystemInfo.appName?.javaScriptLiteralString() ?? "''"),
         appVersion: \(SystemInfo.appVersion?.javaScriptLiteralString() ?? "''"), 
-        device: \(SystemInfo.device?.javaScriptLiteralString() ?? "''"),
+        device: \(SystemInfo.device.javaScriptLiteralString()),
         webauthn: true,
     },
 

--- a/ios/descope-swift-sdk/flows/FlowCoordinator.swift
+++ b/ios/descope-swift-sdk/flows/FlowCoordinator.swift
@@ -61,7 +61,7 @@ public class DescopeFlowCoordinator {
     /// The flow that's currently running in the ``DescopeFlowCoordinator``.
     public private(set) var flow: DescopeFlow? {
         didSet {
-            sdk.resume = resumeClosure
+            sdk.resume = makeResumeClosure(self)
             logger = sdk.config.logger
             bridge.flow = flow
             bridge.logger = logger
@@ -232,7 +232,7 @@ public class DescopeFlowCoordinator {
 
     // Resume
 
-    private func resume(_ url: URL) -> Bool {
+    func resume(_ url: URL) -> Bool {
         guard state == .ready else {
             logger.debug("Ignoring resume URL", state)
             return false
@@ -240,10 +240,6 @@ public class DescopeFlowCoordinator {
         logger.info("Received URL for resuming flow", url)
         sendResponse(.magicLink(url: url.absoluteString))
         return true
-    }
-
-    private lazy var resumeClosure: DescopeSDK.ResumeClosure = { [weak self] url in
-        return self?.resume(url) ?? false
     }
 
     // Events
@@ -447,5 +443,11 @@ private class WebViewLayoutObserver: NSObject {
                 handler()
             }
         })
+    }
+}
+
+private func makeResumeClosure(_ coordinator: DescopeFlowCoordinator) -> DescopeSDK.ResumeClosure {
+    return { [weak coordinator] url in
+        return coordinator?.resume(url) ?? false
     }
 }

--- a/ios/descope-swift-sdk/internal/http/DescopeClient.swift
+++ b/ios/descope-swift-sdk/internal/http/DescopeClient.swift
@@ -297,6 +297,23 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         ])
     }
     
+    // MARK: - Push
+    
+    func pushEnrollDevice(provider: String, token: String, device: String, refreshJwt: String) async throws(DescopeError) {
+        try await post("auth/push/update", headers: authorization(with: refreshJwt), body: [
+            "provider": provider,
+            "token": token,
+            "device": device,
+        ])
+    }
+    
+    func pushSignInFinish(transactionId: String, approved: Bool, refreshJwt: String) async throws(DescopeError) {
+        try await post("auth/push/signin/finish", headers: authorization(with: refreshJwt), body: [
+            "transactionId": transactionId,
+            "result": approved ? "approved" : "denied",
+        ])
+    }
+    
     // MARK: - OAuth
     
     struct OAuthResponse: JSONResponse {
@@ -430,6 +447,7 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         var cookieDomain: String?
         var cookieName: String?
         var sessionCookieName: String?
+        var externalToken: String?
 
         mutating func setValues(from data: Data, response: HTTPURLResponse) throws {
             guard let url = response.url, let fields = response.allHeaderFields as? [String: String] else { return }
@@ -559,6 +577,7 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
             "x-descope-sdk-version": DescopeSDK.version,
             "x-descope-platform-name": SystemInfo.osName,
             "x-descope-platform-version": SystemInfo.osVersion,
+            "x-descope-device": SystemInfo.device,
             "x-descope-project-id": config.projectId,
         ]
         if let appName = SystemInfo.appName, !appName.isEmpty {
@@ -566,9 +585,6 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         }
         if let appVersion = SystemInfo.appVersion, !appVersion.isEmpty {
             headers["x-descope-app-version"] = appVersion
-        }
-        if let device = SystemInfo.device, !device.isEmpty {
-            headers["x-descope-device"] = device
         }
         return headers
     }

--- a/ios/descope-swift-sdk/internal/http/HTTPClient.swift
+++ b/ios/descope-swift-sdk/internal/http/HTTPClient.swift
@@ -85,20 +85,22 @@ class HTTPClient {
         }
 
         if let error = DescopeError(httpStatusCode: response.statusCode) {
+            let cfray = response.value(forHTTPHeaderField: "cf-ray")
+            let trace = cfray.map { " [CF-Ray: \($0)]" } ?? ""
             if let responseError = errorForResponseData(data) {
                 if logger.isUnsafeEnabled {
-                    logger.error("Network call failed with server error", request.url, responseError)
+                    logger.error("Network call failed with server error\(trace)", request.url, responseError)
                 } else {
-                    logger.error("Network call to \(route) failed with \(responseError.code) server error")
+                    logger.error("Network call to \(route) failed with \(responseError.code) server error\(trace)")
                 }
-                throw responseError
+                throw responseError.with(traceId: cfray)
             }
             if logger.isUnsafeEnabled {
-                logger.error("Network call failed with \(response.statusCode) http error", request.url, error)
+                logger.error("Network call failed with \(response.statusCode) http error\(trace)", request.url, error)
             } else {
-                logger.error("Network call to \(route) failed with \(response.statusCode) http error")
+                logger.error("Network call to \(route) failed with \(response.statusCode) http error\(trace)")
             }
-            throw error
+            throw error.with(traceId: cfray)
         }
         
         if logger.isUnsafeEnabled {

--- a/ios/descope-swift-sdk/internal/http/SystemInfo.swift
+++ b/ios/descope-swift-sdk/internal/http/SystemInfo.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if os(iOS)
+import UIKit
+#endif
 
 enum SystemInfo {
     static let osName = makeOSName()
@@ -31,26 +34,28 @@ private func makeAppVersion() -> String? {
     return "\(version).\(build)"
 }
 
-private func makeDevice() -> String? {
+private func makeDevice() -> String {
     #if targetEnvironment(simulator)
     return "Simulator"
     #else
     // use different ioctl name according to os
     #if os(iOS)
     let ioctl = "hw.machine"
+    let fallback = UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone"
     #else
     let ioctl = "hw.model"
+    let fallback = "Mac"
     #endif
 
     // get the size of the value first
     var size = 0
-    guard sysctlbyname(ioctl, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+    guard sysctlbyname(ioctl, nil, &size, nil, 0) == 0, size > 0 else { return fallback }
 
     // create an appropriately sized array and call again to retrieve the value
     var chars = [CChar](repeating: 0, count: size)
-    guard sysctlbyname(ioctl, &chars, &size, nil, 0) == 0 else { return nil }
+    guard sysctlbyname(ioctl, &chars, &size, nil, 0) == 0 else { return fallback }
 
     // the device model, e.g., "MacBookPro18,4" or "iPhone17,2"
-    return String(utf8String: chars)
+    return String(utf8String: chars) ?? fallback
     #endif
 }

--- a/ios/descope-swift-sdk/internal/others/Internal.swift
+++ b/ios/descope-swift-sdk/internal/others/Internal.swift
@@ -6,16 +6,21 @@ extension DescopeSDK {
 }
 
 extension DescopeError {
-    func with(desc: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
-    }
-    
-    func with(message: String) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
-    }
-    
-    func with(cause: Error) -> DescopeError {
-        return DescopeError(code: code, desc: desc, message: message, cause: cause)
+    func with(desc: String? = nil, message: String? = nil, cause: Error? = nil, traceId: String? = nil) -> DescopeError {
+        var error = self
+        if let desc, !desc.isEmpty {
+            error.desc = desc
+        }
+        if let message, !message.isEmpty {
+            error.message = message
+        }
+        if let cause {
+            error.cause = cause
+        }
+        if let traceId, !traceId.isEmpty {
+            error.traceId = traceId
+        }
+        return error
     }
 }
 
@@ -224,6 +229,7 @@ extension AuthenticationResponse: Codable {
         case refreshToken = "refreshJwt"
         case user
         case isFirstAuthentication
+        case externalToken
     }
 
     public init(from decoder: Decoder) throws {
@@ -232,6 +238,7 @@ extension AuthenticationResponse: Codable {
         refreshToken = try Token(jwt: values.decode(String.self, forKey: .refreshToken))
         user = try values.decode(DescopeUser.self, forKey: .user)
         isFirstAuthentication = try values.decode(Bool.self, forKey: .isFirstAuthentication)
+        externalToken = try values.decodeIfPresent(String.self, forKey: .externalToken)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -240,6 +247,7 @@ extension AuthenticationResponse: Codable {
         try values.encode(refreshToken.jwt, forKey: .refreshToken)
         try values.encode(user, forKey: .user)
         try values.encode(isFirstAuthentication, forKey: .isFirstAuthentication)
+        try values.encodeIfPresent(externalToken, forKey: .externalToken)
     }
 }
 

--- a/ios/descope-swift-sdk/internal/routes/Push.swift
+++ b/ios/descope-swift-sdk/internal/routes/Push.swift
@@ -1,0 +1,17 @@
+
+final class Push: DescopePush {
+    let client: DescopeClient
+    
+    init(client: DescopeClient) {
+        self.client = client
+    }
+    
+    func enroll(token: String, development: Bool, refreshJwt: String) async throws(DescopeError) {
+        let provider = development ? "apndev" : "apn"
+        try await client.pushEnrollDevice(provider: provider, token: token, device: SystemInfo.device, refreshJwt: refreshJwt)
+    }
+    
+    func finish(transactionId: String, approved: Bool, refreshJwt: String) async throws(DescopeError) {
+        try await client.pushSignInFinish(transactionId: transactionId, approved: approved, refreshJwt: refreshJwt)
+    }
+}

--- a/ios/descope-swift-sdk/internal/routes/Shared.swift
+++ b/ios/descope-swift-sdk/internal/routes/Shared.swift
@@ -73,7 +73,7 @@ extension DescopeClient.JWTResponse {
         guard let sessionJwt, !sessionJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing session JWT") }
         guard let refreshJwt, !refreshJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing refresh JWT") }
         guard let user else { throw DescopeError.decodeError.with(message: "Missing user details") }
-        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen)
+        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen, externalToken: externalToken)
     }
 }
 

--- a/ios/descope-swift-sdk/sdk/Callbacks.swift
+++ b/ios/descope-swift-sdk/sdk/Callbacks.swift
@@ -967,6 +967,28 @@ public extension DescopePassword {
     }
 }
 
+public extension DescopePush {
+    func enroll(token: String, development: Bool, refreshJwt: String, completion: @escaping @Sendable (Result<Void, DescopeError>) -> Void) {
+        Task {
+            do throws(DescopeError) {
+                completion(.success(try await enroll(token: token, development: development, refreshJwt: refreshJwt)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func finish(transactionId: String, approved: Bool, refreshJwt: String, completion: @escaping @Sendable (Result<Void, DescopeError>) -> Void) {
+        Task {
+            do throws(DescopeError) {
+                completion(.success(try await finish(transactionId: transactionId, approved: approved, refreshJwt: refreshJwt)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
 public extension DescopeSSO {
     /// Starts an SSO redirect chain to authenticate a user.
     /// 

--- a/ios/descope-swift-sdk/sdk/Routes.swift
+++ b/ios/descope-swift-sdk/sdk/Routes.swift
@@ -479,6 +479,33 @@ public protocol DescopeEnchantedLink: Sendable {
 }
 
 
+/// Authenticate users using push notifications.
+///
+/// The push notification authentication works by registering the user's device
+/// via APNs (Apple Push Notification service) and then completing authentication
+/// transactions by approving or denying them.
+public protocol DescopePush: Sendable {
+    /// Registers an APNs device token for push authentication.
+    ///
+    /// The user must have an active ``DescopeSession`` whose `refreshJwt` should be
+    /// passed as a parameter to this function.
+    ///
+    /// - Parameters:
+    ///   - token: The APNs device token to register.
+    ///   - development: Whether the token is for the development or production APNs environment.
+    ///   - refreshJwt: The `refreshJwt` from an active ``DescopeSession``.
+    func enroll(token: String, development: Bool, refreshJwt: String) async throws(DescopeError)
+
+    /// Completes a push authentication transaction by approving or denying it.
+    ///
+    /// - Parameters:
+    ///   - transactionId: The ID of the push authentication transaction.
+    ///   - approved: Whether the authentication request is approved or denied.
+    ///   - refreshJwt: The `refreshJwt` from an active ``DescopeSession``.
+    func finish(transactionId: String, approved: Bool, refreshJwt: String) async throws(DescopeError)
+}
+
+
 /// Authenticate a user using an OAuth provider.
 ///
 /// Use the Descope console to configure which authentication provider you'd like to support.

--- a/ios/descope-swift-sdk/sdk/SDK.swift
+++ b/ios/descope-swift-sdk/sdk/SDK.swift
@@ -30,6 +30,9 @@ public class DescopeSDK {
     /// Provides functions for authentication with enchanted links.
     public let enchantedLink: DescopeEnchantedLink
     
+    /// Provides functions for authentication with push notifications.
+    public let push: DescopePush
+    
     /// Provides functions for authentication with OAuth.
     public let oauth: DescopeOAuth
     
@@ -124,6 +127,7 @@ public class DescopeSDK {
         self.password = Password(client: client)
         self.magicLink = MagicLink(client: client)
         self.enchantedLink = EnchantedLink(client: client)
+        self.push = Push(client: client)
         self.oauth = OAuth(client: client)
         self.sso = SSO(client: client)
         self.accessKey = AccessKey(client: client)
@@ -143,7 +147,7 @@ public extension DescopeSDK {
     static let name = "DescopeKit"
     
     /// The Descope SDK version
-    static let version = "0.10.6"
+    static let version = "0.11.1"
 }
 
 // Internal

--- a/ios/descope-swift-sdk/types/Error.swift
+++ b/ios/descope-swift-sdk/types/Error.swift
@@ -63,6 +63,16 @@ public struct DescopeError: Error {
     /// call. When a ``DescopeError/passkeyFailed`` error is thrown the ``cause`` property
     /// will often contain an instance of AuthorizationError.
     public var cause: Error?
+
+    /// An optional trace identifier for a failed network request.
+    ///
+    /// When the Descope server is accessed through its CDN (the default), this holds the
+    /// value of the `CF-Ray` response header of the failed request. You can log this value
+    /// or send it to Descope support to help trace and diagnose server errors.
+    ///
+    /// This is `nil` for errors that aren't associated with a server response, such as
+    /// ``DescopeError/networkError``, or when the response didn't include the header.
+    public var traceId: String?
 }
 
 /// A list of common ``DescopeError`` values that can be thrown by the Descope SDK.
@@ -142,6 +152,9 @@ extension DescopeError: CustomStringConvertible {
         }
         if let cause {
             str += ", cause: {\(cause)}"
+        }
+        if let traceId {
+            str += ", traceId: \"\(traceId)\""
         }
         str += ")"
         return str

--- a/ios/descope-swift-sdk/types/Responses.swift
+++ b/ios/descope-swift-sdk/types/Responses.swift
@@ -10,6 +10,7 @@ public struct AuthenticationResponse: Sendable {
     public var refreshToken: DescopeToken
     public var user: DescopeUser
     public var isFirstAuthentication: Bool
+    public var externalToken: String?
 }
 
 /// Returned from the ``DescopeAuth/refreshSession(refreshJwt:)`` call.


### PR DESCRIPTION
## Description

Bumps the native SDKs to receive support for:
- `externalToken` 
- passkey and oauth cancellation control
- added the glue for `externalToken`

### Updated SDKs
- descope-swift `0.11.1`
- descope-kotlin `0.19.1`

## Must
- [x] Tests
- [ ] Documentation (if applicable)