### PR TITLE
fix(ci): prevent script injection in update-release-lockfiles workflow

### DIFF
--- a/.github/workflows/update-release-lockfiles.yml
+++ b/.github/workflows/update-release-lockfiles.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update-lockfiles:
-    if: startsWith(github.head_ref, 'release-please--')
+    if: startsWith(github.head_ref, 'release-please--') && github.event.pull_request.head.repo.full_name == github.repository
     name: Refresh example Podfile.lock files
     runs-on: macos-latest
     permissions:
@@ -68,4 +68,4 @@ jobs:
           git config user.email "descope-release-bot[bot]@users.noreply.github.com"
           git add '**/Podfile.lock'
           git commit -m "chore: update example Podfile.lock files"
-          git push origin "HEAD:$HEAD_REF"
+          git push origin "HEAD:refs/heads/$HEAD_REF"

--- a/.github/workflows/update-release-lockfiles.yml
+++ b/.github/workflows/update-release-lockfiles.yml
@@ -57,6 +57,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.CI_NPM_READ_ORG }}
 
       - name: Commit updated Podfile.lock files
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if git diff --quiet -- '**/Podfile.lock'; then
             echo "No Podfile.lock changes; nothing to commit."
@@ -66,4 +68,4 @@ jobs:
           git config user.email "descope-release-bot[bot]@users.noreply.github.com"
           git add '**/Podfile.lock'
           git commit -m "chore: update example Podfile.lock files"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin "HEAD:$HEAD_REF"


### PR DESCRIPTION
Fixes descope/descope-react-native#180

[View Shuni run](https://shuni.descope.ai/sessions?sandbox=iueuhxyqyg5kkk7eafm19)

Fixed and committed (`0fcf8d0`).

`github.head_ref` now flows through an `env:` var and is expanded as `"HEAD:$HEAD_REF"`, so a branch name containing `$(...)`, backticks, or `&&` is treated as literal text by the shell instead of being executed on a runner holding `RELEASE_APP_PEM`/`RELEASE_APP_ID`.

Scanned the rest of the file and every other workflow — no other `github.event.*` / `github.actor` / `github.head_ref` interpolation inside a `run:` block. The remaining expressions (`github.ref` in `concurrency`, `github.event.pull_request.head.sha` in `checkout`'s `with:`) are evaluated by Actions, never by a shell, so they aren't injectable.

skipped: adding actionlint/zizmor to CI — add when you want this class of bug caught automatically rather than by report.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*