### PR TITLE
feat: support native passkeys without running a flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,79 @@ const App = () => {
 
 **For more SDK usage examples refer to [docs](https://docs.descope.com/build/guides/client_sdks/)**
 
+## Passkeys
+
+Passkeys work inside flows out of the box. The `passkey` API lets you authenticate with the
+platform authenticator directly, without running a flow.
+
+Passkeys require **iOS 15** or **Android 9** (API 28). This does not change the minimum versions
+the SDK supports - it is a runtime requirement, so keep your deployment target and
+`minSdkVersion` as they are and use `isSupported()` to decide whether to offer passkeys.
+
+### Setup #1: Configure the project
+
+Enable Passkeys (WebAuthn) in the [Descope Console](https://app.descope.com/settings/authentication/webauthn)
+and set the top level domain. The domain is required - unlike flows, the native API has no
+fallback that derives it from the caller, so passkeys will fail without it.
+
+### Setup #2.1: Associated domains on iOS
+
+Add a [`webcredentials`](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
+associated domain entitlement matching the domain configured above:
+
+```
+webcredentials:example.com
+```
+
+### Setup #2.2: Digital Asset Links on Android
+
+Host an [`assetlinks.json`](https://developer.android.com/training/sign-in/passkeys#add-support-dal)
+file on that same domain, including the `get_login_creds` relation.
+
+Android derives its origin from the app's signing certificate, as
+`android:apk-key-hash:<sha256>`.
+
+Registering these certificate fingerprints in the Descope project is **optional**. If none are
+configured, any Android origin is accepted. Registering them restricts passkey authentication to
+builds you signed, which is recommended for production.
+
+Note that this is all or nothing: as soon as one fingerprint is registered, any origin that does
+not match a registered fingerprint is rejected. Register every certificate you ship with:
+
+- The **debug** certificate, for local development builds.
+- The **release** (upload) certificate.
+- The **Play App Signing** certificate, if the app is distributed through Google Play. Play
+  re-signs the app with a key Google holds, so the certificate that reaches users is not your
+  upload key. Take it from Play Console -> Setup -> App integrity -> App signing.
+
+Omitting the Play App Signing certificate produces a failure that is easy to miss during testing:
+passkeys work in local and internal builds, and fail only for users who installed from the Play
+Store.
+
+### Usage
+
+```js
+import { useDescope, useSession } from '@descope/react-native-sdk'
+
+const descope = useDescope()
+const { manageSession } = useSession()
+
+// authenticates an existing user, or creates one if they don't exist yet
+const resp = await descope.passkey.signUpOrIn('andy@example.com')
+manageSession(resp.data)
+```
+
+`signUp(loginId, name)`, `signIn(loginId)` and `add(loginId, refreshJwt)` are also available.
+
+Check `isSupported()` before offering passkeys, so devices that cannot use them are not shown
+the option:
+
+```js
+if (await descope.passkey.isSupported()) {
+  // show the passkey option
+}
+```
+
 ## Troubleshooting
 
 ### Fixing XCode 26+ Compatibility Issues

--- a/android/src/main/java/com/descopereactnative/DescopeReactNativeModule.kt
+++ b/android/src/main/java/com/descopereactnative/DescopeReactNativeModule.kt
@@ -1,5 +1,6 @@
 package com.descopereactnative
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -10,7 +11,15 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import com.descope.Descope
+import com.descope.internal.routes.getPackageOrigin
+import com.descope.internal.routes.isWebAuthnSupported
+import com.descope.internal.routes.performAssertion
+import com.descope.internal.routes.performRegister
 import com.descope.sdk.DescopeLogger
+import com.descope.types.DescopeException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -23,6 +32,10 @@ import androidx.core.net.toUri
 import androidx.core.content.edit
 
 private const val prefName = "com.descope.reactnative"
+private const val noActivityCode = "no_activity"
+private const val noActivityMessage = "Passkeys require an active activity"
+private const val passkeyUnsupportedCode = "passkey_unsupported"
+private const val passkeyUnsupportedMessage = "Passkeys require Android API 28 or newer"
 
 class DescopeReactNativeModule(private val reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext) {
@@ -127,6 +140,60 @@ class DescopeReactNativeModule(private val reactContext: ReactApplicationContext
     promise.resolve(key)
   }
 
+  // Passkey
+
+  @ReactMethod
+  fun passkeySupported(promise: Promise) {
+    promise.resolve(isWebAuthnSupported)
+  }
+
+  @ReactMethod
+  fun passkeyOrigin(promise: Promise) {
+    val activity = passkeyActivity(promise) ?: return
+    try {
+      promise.resolve(getPackageOrigin(activity))
+    } catch (e: Exception) {
+      promise.rejectPasskey(e)
+    }
+  }
+
+  @ReactMethod
+  fun passkeyCreate(options: String, promise: Promise) {
+    val activity = passkeyActivity(promise) ?: return
+    CoroutineScope(Dispatchers.Main).launch {
+      try {
+        promise.resolve(performRegister(activity, options))
+      } catch (e: Exception) {
+        promise.rejectPasskey(e)
+      }
+    }
+  }
+
+  @ReactMethod
+  fun passkeyAuthenticate(options: String, promise: Promise) {
+    val activity = passkeyActivity(promise) ?: return
+    CoroutineScope(Dispatchers.Main).launch {
+      try {
+        promise.resolve(performAssertion(activity, options))
+      } catch (e: Exception) {
+        promise.rejectPasskey(e)
+      }
+    }
+  }
+
+  private fun passkeyActivity(promise: Promise): Activity? {
+    val activity = activityFromReactContext(reactContext)
+    if (activity == null) {
+      promise.reject(noActivityCode, noActivityMessage)
+      return null
+    }
+    if (!isWebAuthnSupported) {
+      promise.reject(passkeyUnsupportedCode, passkeyUnsupportedMessage)
+      return null
+    }
+    return activity
+  }
+
   companion object {
     const val NAME = "DescopeReactNative"
   }
@@ -162,6 +229,11 @@ private class ReactNativeDescopeLogger(
         .emit("descopeLog", body)
     }
   }
+}
+
+private fun Promise.rejectPasskey(e: Exception) = when (e) {
+  is DescopeException -> reject(e.code, e.desc, e)
+  else -> reject(DescopeException.passkeyFailed.code, e.message ?: DescopeException.passkeyFailed.desc, e)
 }
 
 private fun launchUri(context: Context, uri: Uri) {

--- a/android/src/main/java/com/descopereactnative/DescopeReactNativeModule.kt
+++ b/android/src/main/java/com/descopereactnative/DescopeReactNativeModule.kt
@@ -232,7 +232,7 @@ private class ReactNativeDescopeLogger(
 }
 
 private fun Promise.rejectPasskey(e: Exception) = when (e) {
-  is DescopeException -> reject(e.code, e.message?.let { "${e.desc}: $it" } ?: e.desc, e)
+  is DescopeException -> reject(e.code, e.message ?: e.desc, e)
   else -> reject(DescopeException.passkeyFailed.code, e.message ?: DescopeException.passkeyFailed.desc, e)
 }
 

--- a/android/src/main/java/com/descopereactnative/DescopeReactNativeModule.kt
+++ b/android/src/main/java/com/descopereactnative/DescopeReactNativeModule.kt
@@ -232,7 +232,7 @@ private class ReactNativeDescopeLogger(
 }
 
 private fun Promise.rejectPasskey(e: Exception) = when (e) {
-  is DescopeException -> reject(e.code, e.desc, e)
+  is DescopeException -> reject(e.code, e.message?.let { "${e.desc}: $it" } ?: e.desc, e)
   else -> reject(DescopeException.passkeyFailed.code, e.message ?: DescopeException.passkeyFailed.desc, e)
 }
 

--- a/ios/DescopeReactNative.mm
+++ b/ios/DescopeReactNative.mm
@@ -36,4 +36,18 @@ RCT_EXTERN_METHOD(configureLogging:(NSString *)level
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(passkeySupported:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(passkeyOrigin:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(passkeyCreate:(NSString *)options
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(passkeyAuthenticate:(NSString *)options
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/DescopeReactNative.swift
+++ b/ios/DescopeReactNative.swift
@@ -252,7 +252,7 @@ private func rejectPasskey(_ reject: RCTPromiseRejectBlock, _ error: Error) {
     guard let error = error as? DescopeError else {
         return reject(DescopeError.passkeyFailed.code, error.localizedDescription, error)
     }
-    reject(error.code, error.message.map { "\(error.desc): \($0)" } ?? error.desc, error)
+    reject(error.code, error.message ?? error.desc, error)
 }
 
 private func prepareInitialRequest(for flowURL: String, with codeChallenge: String) throws -> URL {

--- a/ios/DescopeReactNative.swift
+++ b/ios/DescopeReactNative.swift
@@ -79,10 +79,8 @@ class DescopeReactNative: RCTEventEmitter {
         Task { @MainActor in
             do {
                 resolve(try await Passkey.performRegister(options: options, logger: nil))
-            } catch let error as DescopeError {
-                reject(error.code, error.desc, error)
             } catch {
-                reject(DescopeError.passkeyFailed.code, error.localizedDescription, error)
+                rejectPasskey(reject, error)
             }
         }
     }
@@ -93,10 +91,8 @@ class DescopeReactNative: RCTEventEmitter {
         Task { @MainActor in
             do {
                 resolve(try await Passkey.performAssertion(options: options, logger: nil))
-            } catch let error as DescopeError {
-                reject(error.code, error.desc, error)
             } catch {
-                reject(DescopeError.passkeyFailed.code, error.localizedDescription, error)
+                rejectPasskey(reject, error)
             }
         }
     }
@@ -250,6 +246,13 @@ private extension Data {
         guard SecRandomCopyBytes(kSecRandomDefault, count, &bytes) == errSecSuccess else { return nil }
         self = Data(bytes: bytes, count: count)
     }
+}
+
+private func rejectPasskey(_ reject: RCTPromiseRejectBlock, _ error: Error) {
+    guard let error = error as? DescopeError else {
+        return reject(DescopeError.passkeyFailed.code, error.localizedDescription, error)
+    }
+    reject(error.code, error.message.map { "\(error.desc): \($0)" } ?? error.desc, error)
 }
 
 private func prepareInitialRequest(for flowURL: String, with codeChallenge: String) throws -> URL {

--- a/ios/DescopeReactNative.swift
+++ b/ios/DescopeReactNative.swift
@@ -5,6 +5,8 @@ import AuthenticationServices
 private let redirectScheme = "descopeauth"
 private let redirectURL = "\(redirectScheme)://flow"
 private let maxKeyWindowAttempts = 10
+private let passkeyUnsupportedCode = "passkey_unsupported"
+private let passkeyUnsupportedMessage = "Passkeys require iOS 15 or newer"
 
 @objc(DescopeReactNative)
 class DescopeReactNative: RCTEventEmitter {
@@ -51,6 +53,51 @@ class DescopeReactNative: RCTEventEmitter {
                 config.logger = logger
             }
             resolve(nil)
+        }
+    }
+
+    // Passkey
+
+    @objc(passkeySupported:rejecter:)
+    func passkeySupported(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        if #available(iOS 15.0, *) {
+            resolve(true)
+        } else {
+            resolve(false)
+        }
+    }
+
+    // the iOS SDK doesn't send an origin, the server infers it from the project's configured domain
+    @objc(passkeyOrigin:rejecter:)
+    func passkeyOrigin(resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        resolve("")
+    }
+
+    @objc(passkeyCreate:withResolver:withRejecter:)
+    func passkeyCreate(_ options: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard #available(iOS 15.0, *) else { return reject(passkeyUnsupportedCode, passkeyUnsupportedMessage, nil) }
+        Task { @MainActor in
+            do {
+                resolve(try await Passkey.performRegister(options: options, logger: nil))
+            } catch let error as DescopeError {
+                reject(error.code, error.desc, error)
+            } catch {
+                reject(DescopeError.passkeyFailed.code, error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(passkeyAuthenticate:withResolver:withRejecter:)
+    func passkeyAuthenticate(_ options: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard #available(iOS 15.0, *) else { return reject(passkeyUnsupportedCode, passkeyUnsupportedMessage, nil) }
+        Task { @MainActor in
+            do {
+                resolve(try await Passkey.performAssertion(options: options, logger: nil))
+            } catch let error as DescopeError {
+                reject(error.code, error.desc, error)
+            } catch {
+                reject(DescopeError.passkeyFailed.code, error.localizedDescription, error)
+            }
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.67.0",
+    "@descope/core-js-sdk": "2.67.1",
     "base-64": "1.0.0"
   },
   "devDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,4 +9,4 @@ export { default as useFlow } from './hooks/useFlow'
 
 export { getCurrentSessionToken, getCurrentRefreshToken, getCurrentUser } from './helpers'
 
-export type { DescopeSession, DescopeSessionManager, DescopeFlow, FlowOptions, DescopeError } from './types'
+export type { DescopeSession, DescopeSessionManager, DescopeFlow, DescopePasskey, FlowOptions, DescopeError } from './types'

--- a/src/internal/core/passkey.ts
+++ b/src/internal/core/passkey.ts
@@ -1,0 +1,43 @@
+import type { DescopePasskey } from '../../types'
+import DescopeReactNative from '../modules/descopeModule'
+import type { CoreSdk } from './sdk'
+
+export const createPasskey = (sdk: CoreSdk): DescopePasskey => ({
+  isSupported: () => DescopeReactNative.passkeySupported(),
+
+  signUp: async (loginId: string, name: string) => {
+    const origin = await DescopeReactNative.passkeyOrigin()
+    const start = await sdk.webauthn.signUp.start(loginId, origin, name)
+    if (!start.ok || !start.data) return { ...start, data: undefined }
+    const response = await DescopeReactNative.passkeyCreate(start.data.options)
+    return sdk.webauthn.signUp.finish(start.data.transactionId, response)
+  },
+
+  signIn: async (loginId: string) => {
+    const origin = await DescopeReactNative.passkeyOrigin()
+    const start = await sdk.webauthn.signIn.start(loginId, origin)
+    if (!start.ok || !start.data) return { ...start, data: undefined }
+    const response = await DescopeReactNative.passkeyAuthenticate(start.data.options)
+    return sdk.webauthn.signIn.finish(start.data.transactionId, response)
+  },
+
+  signUpOrIn: async (loginId: string) => {
+    const origin = await DescopeReactNative.passkeyOrigin()
+    const start = await sdk.webauthn.signUpOrIn.start(loginId, origin)
+    if (!start.ok || !start.data) return { ...start, data: undefined }
+    const { transactionId, options, create } = start.data
+    // there is no signUpOrIn finish endpoint, the create flag decides which one applies
+    if (create) {
+      return sdk.webauthn.signUp.finish(transactionId, await DescopeReactNative.passkeyCreate(options))
+    }
+    return sdk.webauthn.signIn.finish(transactionId, await DescopeReactNative.passkeyAuthenticate(options))
+  },
+
+  add: async (loginId: string, refreshJwt: string) => {
+    const origin = await DescopeReactNative.passkeyOrigin()
+    const start = await sdk.webauthn.update.start(loginId, origin, refreshJwt)
+    if (!start.ok || !start.data) return { ...start, data: undefined }
+    const response = await DescopeReactNative.passkeyCreate(start.data.options)
+    return sdk.webauthn.update.finish(start.data.transactionId, response)
+  },
+})

--- a/src/internal/core/sdk.ts
+++ b/src/internal/core/sdk.ts
@@ -1,8 +1,10 @@
 import createCoreSdk, { type ExtendedResponse } from '@descope/core-js-sdk'
 import { Platform } from 'react-native'
 import { version } from '../../../package.json'
+import { createPasskey } from './passkey'
 
 export type Sdk = ReturnType<typeof createSdk>
+export type CoreSdk = ReturnType<typeof createCoreSdk>
 export type SdkLogger = Parameters<typeof createCoreSdk>[0]['logger']
 export type SdkConfig = Parameters<typeof createCoreSdk>
 
@@ -16,7 +18,8 @@ export const createSdk = (...config: SdkConfig) => {
       config[0].hooks.transformResponse = parseCookies
     }
   }
-  return createCoreSdk(...config)
+  const coreSdk = createCoreSdk(...config)
+  return { ...coreSdk, passkey: createPasskey(coreSdk) }
 }
 
 const parseCookies = async (mutableResponse: ExtendedResponse) => {

--- a/src/internal/modules/descopeModule.ts
+++ b/src/internal/modules/descopeModule.ts
@@ -14,5 +14,9 @@ interface DescopeNative {
   saveItem(key: string, value: string): Promise<string>
   removeItem(key: string): Promise<string>
   configureLogging(level: string, unsafe: boolean): Promise<void>
+  passkeySupported(): Promise<boolean>
+  passkeyOrigin(): Promise<string>
+  passkeyCreate(options: string): Promise<string>
+  passkeyAuthenticate(options: string): Promise<string>
 }
 export default DescopeReactNative as DescopeNative

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,75 @@ export interface DescopeSessionManager {
   updateUser(userResponse: UserResponse): Promise<void>
 }
 
+/**
+ * Authenticate users using a passkey (WebAuthn) with the platform authenticator,
+ * without running a flow.
+ *
+ * The authentication functions in this interface are all asynchronous operations
+ * that perform network requests before and after displaying the modal authentication
+ * view. It is thus recommended to show an activity indicator or switch the user interface
+ * to a loading state before calling these functions, otherwise the user might accidentally
+ * interact with the app when the authentication view is not being displayed.
+ *
+ * Passkeys require iOS 15 or Android 9 (API 28) at runtime, and associated domains (iOS)
+ * or Digital Asset Links (Android) to be configured. See the README for the full setup.
+ *
+ *     import { useDescope, useSession } from '@descope/react-native-sdk'
+ *
+ *     const descope = useDescope()
+ *     const { manageSession } = useSession()
+ *
+ *     const resp = await descope.passkey.signUpOrIn('andy@example.com')
+ *     manageSession(resp.data)
+ */
+export interface DescopePasskey {
+  /**
+   * Whether the current device supports passkeys.
+   *
+   * Call this before offering a passkey option, as the SDK itself supports OS versions
+   * older than passkeys require.
+   */
+  isSupported(): Promise<boolean>
+  /**
+   * Authenticates a new user by creating a new passkey.
+   *
+   * @param loginId What identifies the user when logging in, typically an email,
+   * phone, or any other unique identifier.
+   * @param name The user's display name. Unlike the other mobile SDKs it is required
+   * here, as the underlying `core-js-sdk` validates it as a non-empty string.
+   * @throws Rejects with `passkeyCancelled` if the authentication view is cancelled by the user.
+   */
+  signUp(loginId: string, name: string): Promise<SdkResponse<JWTResponse>>
+  /**
+   * Authenticates an existing user by prompting for an existing passkey.
+   *
+   * @param loginId What identifies the user when logging in, typically an email,
+   * phone, or any other unique identifier.
+   * @throws Rejects with `passkeyCancelled` if the authentication view is cancelled by the user.
+   */
+  signIn(loginId: string): Promise<SdkResponse<JWTResponse>>
+  /**
+   * Authenticates an existing user if one exists or creates a new one.
+   *
+   * A new passkey will be created if the user doesn't already exist, otherwise a passkey
+   * must be available on their device to authenticate with.
+   *
+   * @param loginId What identifies the user when logging in, typically an email,
+   * phone, or any other unique identifier.
+   * @throws Rejects with `passkeyCancelled` if the authentication view is cancelled by the user.
+   */
+  signUpOrIn(loginId: string): Promise<SdkResponse<JWTResponse>>
+  /**
+   * Updates an existing user by adding a new passkey as an authentication method.
+   *
+   * @param loginId What identifies the user when logging in, typically an email,
+   * phone, or any other unique identifier.
+   * @param refreshJwt The `refreshJwt` from an active `DescopeSession`.
+   * @throws Rejects with `passkeyCancelled` if the authentication view is cancelled by the user.
+   */
+  add(loginId: string, refreshJwt: string): Promise<SdkResponse<{ jwt?: JWTResponse }>>
+}
+
 /** An error that can return from various SDK operation */
 export type DescopeError = {
   errorCode: string

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -12,6 +12,10 @@ jest.mock('../src/internal/modules/descopeModule', () => ({
   default: {
     loadItem: jest.fn().mockResolvedValue(null),
     configureLogging: jest.fn().mockResolvedValue(null),
+    passkeySupported: jest.fn().mockResolvedValue(true),
+    passkeyOrigin: jest.fn().mockResolvedValue(''),
+    passkeyCreate: jest.fn().mockResolvedValue(''),
+    passkeyAuthenticate: jest.fn().mockResolvedValue(''),
   },
 }))
 

--- a/test/Passkey.test.ts
+++ b/test/Passkey.test.ts
@@ -1,0 +1,133 @@
+import { createPasskey } from '../src/internal/core/passkey'
+import DescopeReactNative from '../src/internal/modules/descopeModule'
+import type { CoreSdk } from '../src/internal/core/sdk'
+
+jest.mock('../src/internal/modules/descopeModule', () => ({
+  __esModule: true,
+  default: {
+    passkeySupported: jest.fn(),
+    passkeyOrigin: jest.fn(),
+    passkeyCreate: jest.fn(),
+    passkeyAuthenticate: jest.fn(),
+  },
+}))
+
+const native = DescopeReactNative as jest.Mocked<typeof DescopeReactNative>
+
+const startResponse = (create: boolean) => ({
+  ok: true,
+  data: { transactionId: 'tx1', options: '{"publicKey":{}}', create },
+})
+
+const jwtResponse = { ok: true, data: { sessionJwt: 'session', refreshJwt: 'refresh' } }
+
+const createMockSdk = () =>
+  ({
+    webauthn: {
+      signUp: { start: jest.fn(), finish: jest.fn().mockResolvedValue(jwtResponse) },
+      signIn: { start: jest.fn(), finish: jest.fn().mockResolvedValue(jwtResponse) },
+      signUpOrIn: { start: jest.fn() },
+      update: { start: jest.fn(), finish: jest.fn().mockResolvedValue({ ok: true, data: {} }) },
+    },
+  }) as unknown as CoreSdk
+
+describe('passkey', () => {
+  let sdk: CoreSdk
+  let passkey: ReturnType<typeof createPasskey>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    native.passkeyOrigin.mockResolvedValue('')
+    native.passkeyCreate.mockResolvedValue('{"registration":true}')
+    native.passkeyAuthenticate.mockResolvedValue('{"assertion":true}')
+    sdk = createMockSdk()
+    passkey = createPasskey(sdk)
+  })
+
+  it('should report platform support from the native module', async () => {
+    native.passkeySupported.mockResolvedValue(false)
+    expect(await passkey.isSupported()).toBe(false)
+  })
+
+  it('should run the register ceremony and finish sign up', async () => {
+    sdk.webauthn.signUp.start = jest.fn().mockResolvedValue(startResponse(true))
+
+    const resp = await passkey.signUp('andy@example.com', 'Andy')
+
+    expect(sdk.webauthn.signUp.start).toHaveBeenCalledWith('andy@example.com', '', 'Andy')
+    expect(native.passkeyCreate).toHaveBeenCalledWith('{"publicKey":{}}')
+    expect(sdk.webauthn.signUp.finish).toHaveBeenCalledWith('tx1', '{"registration":true}')
+    expect(resp).toBe(jwtResponse)
+  })
+
+  it('should run the assertion ceremony and finish sign in', async () => {
+    sdk.webauthn.signIn.start = jest.fn().mockResolvedValue(startResponse(false))
+
+    const resp = await passkey.signIn('andy@example.com')
+
+    expect(native.passkeyAuthenticate).toHaveBeenCalledWith('{"publicKey":{}}')
+    expect(sdk.webauthn.signIn.finish).toHaveBeenCalledWith('tx1', '{"assertion":true}')
+    expect(resp).toBe(jwtResponse)
+  })
+
+  it('should register and finish sign up when signUpOrIn returns create', async () => {
+    sdk.webauthn.signUpOrIn.start = jest.fn().mockResolvedValue(startResponse(true))
+
+    await passkey.signUpOrIn('andy@example.com')
+
+    expect(native.passkeyCreate).toHaveBeenCalledWith('{"publicKey":{}}')
+    expect(native.passkeyAuthenticate).not.toHaveBeenCalled()
+    expect(sdk.webauthn.signUp.finish).toHaveBeenCalledWith('tx1', '{"registration":true}')
+    expect(sdk.webauthn.signIn.finish).not.toHaveBeenCalled()
+  })
+
+  it('should assert and finish sign in when signUpOrIn does not return create', async () => {
+    sdk.webauthn.signUpOrIn.start = jest.fn().mockResolvedValue(startResponse(false))
+
+    await passkey.signUpOrIn('andy@example.com')
+
+    expect(native.passkeyAuthenticate).toHaveBeenCalledWith('{"publicKey":{}}')
+    expect(native.passkeyCreate).not.toHaveBeenCalled()
+    expect(sdk.webauthn.signIn.finish).toHaveBeenCalledWith('tx1', '{"assertion":true}')
+    expect(sdk.webauthn.signUp.finish).not.toHaveBeenCalled()
+  })
+
+  it('should pass the refresh token when adding a passkey', async () => {
+    sdk.webauthn.update.start = jest.fn().mockResolvedValue(startResponse(true))
+
+    await passkey.add('andy@example.com', 'refresh-jwt')
+
+    expect(sdk.webauthn.update.start).toHaveBeenCalledWith('andy@example.com', '', 'refresh-jwt')
+    expect(sdk.webauthn.update.finish).toHaveBeenCalledWith('tx1', '{"registration":true}')
+  })
+
+  it('should send the origin provided by the native module', async () => {
+    native.passkeyOrigin.mockResolvedValue('android:apk-key-hash:abc')
+    sdk.webauthn.signUpOrIn.start = jest.fn().mockResolvedValue(startResponse(false))
+
+    await passkey.signUpOrIn('andy@example.com')
+
+    expect(sdk.webauthn.signUpOrIn.start).toHaveBeenCalledWith('andy@example.com', 'android:apk-key-hash:abc')
+  })
+
+  it('should not run a ceremony when start fails', async () => {
+    const failure = { ok: false, error: { errorCode: 'E062108', errorDescription: 'User not found' } }
+    sdk.webauthn.signIn.start = jest.fn().mockResolvedValue(failure)
+
+    const resp = await passkey.signIn('andy@example.com')
+
+    expect(resp.ok).toBe(false)
+    expect(resp.data).toBeUndefined()
+    expect(resp.error).toBe(failure.error)
+    expect(native.passkeyAuthenticate).not.toHaveBeenCalled()
+    expect(sdk.webauthn.signIn.finish).not.toHaveBeenCalled()
+  })
+
+  it('should propagate a cancelled ceremony', async () => {
+    sdk.webauthn.signIn.start = jest.fn().mockResolvedValue(startResponse(false))
+    native.passkeyAuthenticate.mockRejectedValue(new Error('Passkey authentication cancelled'))
+
+    await expect(passkey.signIn('andy@example.com')).rejects.toThrow('Passkey authentication cancelled')
+    expect(sdk.webauthn.signIn.finish).not.toHaveBeenCalled()
+  })
+})

--- a/test/SessionRefresh.test.tsx
+++ b/test/SessionRefresh.test.tsx
@@ -19,6 +19,10 @@ jest.mock('../src/internal/modules/descopeModule', () => ({
     saveItem: jest.fn().mockResolvedValue(''),
     removeItem: jest.fn().mockResolvedValue(''),
     configureLogging: jest.fn().mockResolvedValue(undefined),
+    passkeySupported: jest.fn().mockResolvedValue(true),
+    passkeyOrigin: jest.fn().mockResolvedValue(''),
+    passkeyCreate: jest.fn().mockResolvedValue(''),
+    passkeyAuthenticate: jest.fn().mockResolvedValue(''),
   },
 }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,10 +1672,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@descope/core-js-sdk@2.67.0":
-  version "2.67.0"
-  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.67.0.tgz#ddc550cadd3de3c4fb3fd934013a90eb3c3b1611"
-  integrity sha512-KOnmnhdePQ4JGNdy3sXH+YXWdo7bAbAjyg9NdkViS0E14MrOZDAXDPv6zP7T3akD2e6Q4KWOaG7dNurP8bCWiA==
+"@descope/core-js-sdk@2.67.1":
+  version "2.67.1"
+  resolved "https://registry.yarnpkg.com/@descope/core-js-sdk/-/core-js-sdk-2.67.1.tgz#6d2d22b76270a9bfcb38dd83b48f833d0deb0c2f"
+  integrity sha512-aRZ8w0MhZG5KPjq7hmfbZiVR/pzlrwOc2ohmSVQZboNdgxmFj1RZN0crs1AoAyz2iLMGhM8+2YBZGSF0fE4gXQ==
   dependencies:
     jwt-decode "4.0.0"
     tslib "2.8.1"


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/5336

## Description

- Add `descope.passkey` with `isSupported`, `signUp`, `signIn`, `signUpOrIn` and `add`, matching the passkey API in the native Swift, Kotlin and Flutter SDKs
- Bump `@descope/core-js-sdk` to `2.67.1`, which allows the empty `origin` that native clients send
- Document passkey setup in the README, including associated domains, Digital Asset Links, and the optional Android signing certificate registration

## Must

- [x] Tests
- [x] Documentation (if applicable)
