### PR TITLE
feat: surface flowOutput from flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,19 @@ const flowUrl = 'https://myflowUrl.com'
 />
 ```
 
+### Flow Output
+
+Flows can return custom data by setting a flow output in the Descope console. When present,
+it's available on the `flowOutput` field of the response the flow finishes with. The object
+is empty for authentications that don't originate from a flow.
+
+```js
+onSuccess={async (jwtResponse) => {
+  const orgId = jwtResponse.flowOutput.organizationId as string | undefined
+  // ...
+}}
+```
+
 ## Use the `useDescope` and `useSession` hooks in your components in order to get authentication state, user details and utilities
 
 This can be helpful to implement application-specific logic. Examples:

--- a/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -53,6 +53,7 @@ import java.net.HttpCookie
 import java.util.Timer
 import java.util.TimerTask
 import kotlin.concurrent.timer
+import androidx.core.net.toUri
 
 @SuppressLint("SetJavaScriptEnabled")
 class DescopeFlowCoordinator(val webView: WebView) {
@@ -141,16 +142,38 @@ class DescopeFlowCoordinator(val webView: WebView) {
     }
 
     private fun handleFinish(data: String?, url: String) {
-        if (data != null) {
-            handleAuthentication(data, url)
-            return
+        val jwtServerResponse = parseJwtServerResponse(data, url)
+        if (jwtServerResponse != null) {
+            try {
+                val authResponse = jwtServerResponse.convert()
+                logger.debug("Flow received an authentication response", data)
+                handleSuccess(authResponse)
+                return
+            } catch (_: Exception) {
+                logger.debug("Flow received a partial authentication response")
+            }
         }
         val session = currentSession
         if (session != null) {
-            handleSuccess(AuthenticationResponse(sessionToken = session.sessionToken, refreshToken = session.refreshToken, user = session.user, isFirstAuthentication = false))
+            handleSuccess(AuthenticationResponse(sessionToken = session.sessionToken, refreshToken = session.refreshToken, user = session.user, isFirstAuthentication = false, flowOutput = jwtServerResponse?.flowOutput ?: emptyMap()))
             return
         }
         handleError(DescopeException.flowFailed.with(message = "No valid authentication tokens found"))
+    }
+
+    private fun parseJwtServerResponse(data: String?, url: String): JwtServerResponse? {
+        if (data == null) return null
+        return try {
+            val jwtServerResponse = JwtServerResponse.fromJson(data, emptyList())
+            // take tokens from cookies if missing
+            val respCookieString = CookieManager.getInstance().getCookie("https://${jwtServerResponse.cookieDomain}${jwtServerResponse.cookiePath}")
+            val urlCookieString = CookieManager.getInstance().getCookie(url)
+            jwtServerResponse.sessionJwt = jwtServerResponse.sessionJwt ?: findJwtInCookies(jwtServerResponse.sessionCookieName ?: SESSION_COOKIE_NAME, respCookieString, urlCookieString)
+            jwtServerResponse.refreshJwt = jwtServerResponse.refreshJwt ?: findJwtInCookies(jwtServerResponse.cookieName ?: bridge.attributes.refreshCookieName ?: REFRESH_COOKIE_NAME, respCookieString, urlCookieString)
+            return jwtServerResponse
+        } catch (_: Exception) {
+            null
+        }
     }
 
     // Initialize
@@ -245,23 +268,6 @@ class DescopeFlowCoordinator(val webView: WebView) {
         stopTimer()
         state = Finished
         listener?.onSuccess(authResponse)
-    }
-
-    private fun handleAuthentication(data: String, url: String) {
-        try {
-            val jwtServerResponse = JwtServerResponse.fromJson(data, emptyList())
-            // take tokens from cookies if missing
-            val respCookieString = CookieManager.getInstance().getCookie("https://${jwtServerResponse.cookieDomain}${jwtServerResponse.cookiePath}")
-            val urlCookieString = CookieManager.getInstance().getCookie(url)
-            jwtServerResponse.sessionJwt = jwtServerResponse.sessionJwt ?: findJwtInCookies(jwtServerResponse.sessionCookieName ?: SESSION_COOKIE_NAME, respCookieString, urlCookieString)
-            jwtServerResponse.refreshJwt = jwtServerResponse.refreshJwt ?: findJwtInCookies(jwtServerResponse.cookieName ?: bridge.attributes.refreshCookieName ?: REFRESH_COOKIE_NAME, respCookieString, urlCookieString)
-            val authResponse = jwtServerResponse.convert()
-            logger.debug("Flow received an authentication response", data)
-            handleSuccess(authResponse)
-        } catch (e: DescopeException) {
-            logger.error("Unexpected error handling authentication response", e, data, url)
-            handleError(DescopeException.flowFailed.with(message = "No valid authentication tokens found"))
-        }
     }
 
     private fun ensureState(vararg allowedStates: DescopeFlowView.State): Boolean {
@@ -435,7 +441,7 @@ internal fun findJwtInCookies(name: String, vararg cookieStrings: String?): Stri
 // Default Browser
 
 private fun shouldUseCustomSchemeUrl(context: Context): Boolean {
-    val browserIntent = Intent("android.intent.action.VIEW", Uri.parse("http://"))
+    val browserIntent = Intent("android.intent.action.VIEW", "http://".toUri())
     val resolveInfo = context.packageManager.resolveActivity(browserIntent, PackageManager.MATCH_DEFAULT_ONLY)
     val label = resolveInfo?.loadLabel(context.packageManager).toString()
     return when (label.lowercase()) {

--- a/android/src/main/java/com/descope/internal/http/HttpClient.kt
+++ b/android/src/main/java/com/descope/internal/http/HttpClient.kt
@@ -73,20 +73,22 @@ internal open class HttpClient(
 
         val result = try {
             val response = networkClient.sendRequest(url, method, body, combinedHeaders)
-            if (response.code != HttpsURLConnection.HTTP_OK) {
-                exceptionFromResponse(response.body)?.let { e ->
+            if (response.code !in 200..299) {
+                val cfRay = response.headers.entries.find { it.key.equals("cf-ray", ignoreCase = true) }?.value?.firstOrNull()
+                val trace = if (cfRay != null) " [CF-Ray: $cfRay]" else ""
+                exceptionFromResponse(response.body)?.with(traceId = cfRay)?.let { e ->
                     if (logger.isUnsafeEnabled) {
-                        logger.error("Network call failed with server error", url, e)
+                        logger.error("Network call failed with server error$trace", url, e)
                     } else {
-                        logger.error("Network call to $route failed with ${e.code} server error")
+                        logger.error("Network call to $route failed with ${e.code} server error$trace")
                     }
                     throw e
                 }
-                exceptionFromResponseCode(response.code)?.let { e ->
+                exceptionFromResponseCode(response.code)?.with(traceId = cfRay)?.let { e ->
                     if (logger.isUnsafeEnabled) {
-                        logger.error("Network call failed with ${response.code} http error", url, e)
+                        logger.error("Network call failed with ${response.code} http error$trace", url, e)
                     } else {
-                        logger.error("Network call to $route failed with ${response.code} http error")
+                        logger.error("Network call to $route failed with ${response.code} http error$trace")
                     }
                     throw e
                 }
@@ -166,7 +168,7 @@ private fun defaultNetworkClient(logger: DescopeLogger?) = object : DescopeNetwo
 
             // Return response
             val responseCode = connection.responseCode
-            val responseBody = if (responseCode == HttpsURLConnection.HTTP_OK) {
+            val responseBody = if (responseCode in 200..299) {
                 connection.inputStream.bufferedReader().use { it.readText() }
             } else {
                 connection.errorStream.bufferedReader().use { it.readText() }

--- a/android/src/main/java/com/descope/internal/http/Responses.kt
+++ b/android/src/main/java/com/descope/internal/http/Responses.kt
@@ -22,6 +22,7 @@ internal data class JwtServerResponse(
     val cookieName: String?,
     val sessionCookieName: String?,
     val externalToken: String?,
+    val flowOutput: Map<String, Any>,
 ) {
     companion object {
         fun fromJson(json: String, cookies: List<HttpCookie>) = JSONObject(json).run {
@@ -51,6 +52,7 @@ internal data class JwtServerResponse(
                 cookieName = cookieName,
                 sessionCookieName = sessionCookieName,
                 externalToken = stringOrEmptyAsNull("externalToken"),
+                flowOutput = optionalMap("flowOutput"),
             )
         }
     }

--- a/android/src/main/java/com/descope/internal/others/ActivityHelper.kt
+++ b/android/src/main/java/com/descope/internal/others/ActivityHelper.kt
@@ -58,6 +58,14 @@ internal val activityHelper = object : ActivityHelper {
     private fun isBrowserSupported(context: Context, uri: Uri): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, uri)
         val component = intent.resolveActivity(context.packageManager)
-        return component != null
+        return when {
+            component != null -> true
+            uri.scheme?.equals("http", ignoreCase = true) == true || uri.scheme?.equals("https", ignoreCase = true) == true -> {
+                val browserIntent = Intent(Intent.ACTION_VIEW, Uri.fromParts("https", "", null))
+                    .addCategory(Intent.CATEGORY_BROWSABLE)
+                context.packageManager.queryIntentActivities(browserIntent, 0).isNotEmpty()
+            }
+            else -> false
+        }
     }
 }

--- a/android/src/main/java/com/descope/internal/others/Errors.kt
+++ b/android/src/main/java/com/descope/internal/others/Errors.kt
@@ -3,11 +3,12 @@ package com.descope.internal.others
 import com.descope.types.DescopeException
 import org.json.JSONObject
 
-internal fun DescopeException.with(desc: String? = null, message: String? = null, cause: Throwable? = null) = DescopeException(
+internal fun DescopeException.with(desc: String? = null, message: String? = null, cause: Throwable? = null, traceId: String? = null) = DescopeException(
     code = code,
     desc = desc ?: this.desc,
     message = message ?: this.message,
     cause = cause ?: this.cause,
+    traceId = traceId ?: this.traceId,
 )
 
 internal fun parseServerError(response: String): DescopeException? {

--- a/android/src/main/java/com/descope/internal/routes/Shared.kt
+++ b/android/src/main/java/com/descope/internal/routes/Shared.kt
@@ -59,9 +59,10 @@ internal fun JwtServerResponse.convert(): AuthenticationResponse {
     return AuthenticationResponse(
         refreshToken = Token(refreshJwt),
         sessionToken = Token(sessionJwt),
+        externalToken = externalToken,
         user = user.convert(),
         isFirstAuthentication = firstSeen,
-        externalToken = externalToken,
+        flowOutput = flowOutput,
     )
 }
 

--- a/android/src/main/java/com/descope/sdk/Sdk.kt
+++ b/android/src/main/java/com/descope/sdk/Sdk.kt
@@ -104,6 +104,6 @@ class DescopeSdk(context: Context, projectId: String, configure: DescopeConfig.(
         const val NAME = "DescopeAndroid"
 
         /** The Descope SDK version */
-        const val VERSION = "0.19.1" // x-release-please-version
+        const val VERSION = "0.20.0" // x-release-please-version
     }
 }

--- a/android/src/main/java/com/descope/types/Error.kt
+++ b/android/src/main/java/com/descope/types/Error.kt
@@ -49,12 +49,18 @@ private const val API_DESC = "Descope API error"
  * @property cause An optional underlying [Throwable] that caused this error.
  * For example, when a [DescopeException.networkError] is caught the [cause] property
  * will usually have the [Exception] object thrown by the internal `HttpsURLConnection` call.
+ * @property traceId An optional trace identifier for a failed network request.
+ * When the Descope server is accessed through its CDN (the default), this holds the value
+ * of the `CF-Ray` response header of the failed request. You can log this value or send it
+ * to Descope support to help trace and diagnose server errors. It is `null` for errors not
+ * associated with a server response, such as [DescopeException.networkError].
  */
 class DescopeException(
     val code: String,
     val desc: String,
     override val message: String? = null,
     override val cause: Throwable? = null,
+    val traceId: String? = null,
 ) : Exception(), Comparable<DescopeException> {
     
     override fun compareTo(other: DescopeException): Int {
@@ -79,6 +85,9 @@ class DescopeException(
         }
         cause?.run {
             str += ", cause: {$this}"
+        }
+        traceId?.run {
+            str += """, traceId: "$this""""
         }
         str += ")"
         return str

--- a/android/src/main/java/com/descope/types/Responses.kt
+++ b/android/src/main/java/com/descope/types/Responses.kt
@@ -7,16 +7,18 @@ import com.descope.session.DescopeToken
  *
  * @property sessionToken the user's session token is used to perform authorized backend requests.
  * @property refreshToken the refresh token is used to refresh expired session tokens.
+ * @property externalToken a token provided by an external token connector, when configured in the project.
  * @property isFirstAuthentication whether this the user's first authentication.
  * @property user information about the user.
- * @property externalToken a token provided by an external token connector, when configured in the project.
+ * @property flowOutput custom data returned from a flow's output, when running a flow that sets it. Empty for non-flow authentications.
  */
 data class AuthenticationResponse(
     val sessionToken: DescopeToken,
     val refreshToken: DescopeToken,
+    val externalToken: String? = null,
     val isFirstAuthentication: Boolean,
     val user: DescopeUser,
-    val externalToken: String? = null,
+    val flowOutput: Map<String, Any> = emptyMap(),
 )
 
 /**

--- a/android/src/main/java/com/descopereactnative/DescopeFlowViewManager.kt
+++ b/android/src/main/java/com/descopereactnative/DescopeFlowViewManager.kt
@@ -196,6 +196,7 @@ private fun AuthenticationResponse.toJsonString(): String {
     put("user", user.toJson())
     put("firstSeen", isFirstAuthentication)
     externalToken?.run { put("externalToken", this) }
+    if (flowOutput.isNotEmpty()) put("flowOutput", flowOutput.toJsonObject())
   }
   return json.toString()
 }

--- a/ios/descope-swift-sdk/flows/FlowCoordinator.swift
+++ b/ios/descope-swift-sdk/flows/FlowCoordinator.swift
@@ -307,25 +307,40 @@ public class DescopeFlowCoordinator {
     }
 
     // Authentication
-
-    private func handleAuthentication(_ data: Data) {
-        logger.info("Finishing flow authentication")
-        Task {
-            guard let authResponse = await parseAuthentication(data) else { return }
-            handleSuccess(authResponse)
+    
+    private func handleData(_ data: Data?) async {
+        let jwtResponse = await parseJWTResponse(data)
+        if let jwtResponse {
+            do {
+                let authResponse = try jwtResponse.convert()
+                logger.debug("Finishing flow with an authentication response", data)
+                return handleSuccess(authResponse)
+            } catch {
+                logger.debug("Finishing flow with a partial authentication response")
+            }
         }
+
+        if let session = flow?.providedSession {
+            if jwtResponse == nil {
+                logger.info("Finishing flow authentication without an authentication response")
+            }
+            return handleSuccess(AuthenticationResponse(sessionToken: session.sessionToken, refreshToken: session.refreshToken, user: session.user, isFirstAuthentication: false, flowOutput: jwtResponse?.flowOutput ?? [:]))
+        }
+        
+        logger.error("Couldn't find session to finish flow", flow?.sessionProvider == nil ? "nil provider" : "custom provider")
+        handleError(DescopeError.flowFailed.with(message: "No valid authentication tokens found"))
     }
 
-    private func parseAuthentication(_ data: Data) async -> AuthenticationResponse? {
+    private func parseJWTResponse(_ data: Data?) async -> DescopeClient.JWTResponse? {
+        guard let data, let webView else { return nil }
         do {
-            guard let webView else { return nil }
             var jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
             let cookies = await webView.configuration.websiteDataStore.httpCookieStore.cookies(for: jwtResponse.cookieDomain, at: webView.url)
             try jwtResponse.setValues(from: data, cookies: cookies, refreshCookieName: bridge.attributes.refreshCookieName)
-            return try jwtResponse.convert()
+            return jwtResponse
         } catch {
+            // should never happen because all JWTResponse fields are optional
             logger.error("Unexpected error parsing authentication response", error, String(bytes: data, encoding: .utf8))
-            handleError(DescopeError.flowFailed.with(message: "No valid authentication response found"))
             return nil
         }
     }
@@ -401,13 +416,8 @@ extension DescopeFlowCoordinator: FlowBridgeDelegate {
     }
 
     func bridgeDidFinish(_ bridge: FlowBridge, data: Data?) {
-        if let data {
-            handleAuthentication(data)
-        } else if let session = flow?.providedSession {
-            handleSuccess(AuthenticationResponse(sessionToken: session.sessionToken, refreshToken: session.refreshToken, user: session.user, isFirstAuthentication: false))
-        } else {
-            logger.error("Couldn't find session to finish flow", flow?.sessionProvider == nil ? "nil provider" : "custom provider")
-            handleError(DescopeError.flowFailed.with(message: "No valid authentication tokens found"))
+        Task { @MainActor in
+            await handleData(data)
         }
     }
 }

--- a/ios/descope-swift-sdk/internal/http/DescopeClient.swift
+++ b/ios/descope-swift-sdk/internal/http/DescopeClient.swift
@@ -443,11 +443,18 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         var sessionJwt: String?
         var refreshJwt: String?
         var user: UserResponse?
-        var firstSeen: Bool
+        var firstSeen: Bool?
         var cookieDomain: String?
         var cookieName: String?
         var sessionCookieName: String?
         var externalToken: String?
+        var flowOutput: [String: Any]?
+
+        // we enumerate the properties explicitly to skip over flowOutput, whose
+        // arbitrary JSON object is populated separately in setValues below
+        enum CodingKeys: String, CodingKey {
+            case sessionJwt, refreshJwt, user, firstSeen, cookieDomain, cookieName, sessionCookieName, externalToken
+        }
 
         mutating func setValues(from data: Data, response: HTTPURLResponse) throws {
             guard let url = response.url, let fields = response.allHeaderFields as? [String: String] else { return }
@@ -462,6 +469,9 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
             if let dict = json["user"] as? [String: Any] {
                 user?.setCustomAttributes(from: dict)
+            }
+            if let output = json["flowOutput"] as? [String: Any], !output.isEmpty {
+                flowOutput = output
             }
             if sessionJwt == nil || sessionJwt == "" {
                 let name = (sessionCookieName == "" ? nil : sessionCookieName) ?? DescopeClient.sessionCookieName

--- a/ios/descope-swift-sdk/internal/others/Internal.swift
+++ b/ios/descope-swift-sdk/internal/others/Internal.swift
@@ -227,9 +227,10 @@ extension AuthenticationResponse: Codable {
     enum CodingKeys: String, CodingKey {
         case sessionToken = "sessionJwt"
         case refreshToken = "refreshJwt"
+        case externalToken
         case user
         case isFirstAuthentication
-        case externalToken
+        case flowOutput
     }
 
     public init(from decoder: Decoder) throws {
@@ -239,6 +240,11 @@ extension AuthenticationResponse: Codable {
         user = try values.decode(DescopeUser.self, forKey: .user)
         isFirstAuthentication = try values.decode(Bool.self, forKey: .isFirstAuthentication)
         externalToken = try values.decodeIfPresent(String.self, forKey: .externalToken)
+        if let value = try values.decodeIfPresent(String.self, forKey: .flowOutput) {
+            flowOutput = (try? JSONSerialization.jsonObject(with: Data(value.utf8))) as? [String: Any] ?? [:]
+        } else {
+            flowOutput = [:]
+        }
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -248,6 +254,11 @@ extension AuthenticationResponse: Codable {
         try values.encode(user, forKey: .user)
         try values.encode(isFirstAuthentication, forKey: .isFirstAuthentication)
         try values.encodeIfPresent(externalToken, forKey: .externalToken)
+        if !flowOutput.isEmpty, JSONSerialization.isValidJSONObject(flowOutput) {
+            let data = try JSONSerialization.data(withJSONObject: flowOutput)
+            let value = String(bytes: data, encoding: .utf8)
+            try values.encodeIfPresent(value, forKey: .flowOutput)
+        }
     }
 }
 

--- a/ios/descope-swift-sdk/internal/routes/Auth.swift
+++ b/ios/descope-swift-sdk/internal/routes/Auth.swift
@@ -21,7 +21,7 @@ final class Auth: DescopeAuth {
     func migrateSession(externalToken: String) async throws(DescopeError) -> AuthenticationResponse {
         let response: MigrateResponse = try await client.migrate(externalToken: externalToken).convert()
         let user = try await me(refreshJwt: response.refreshToken.jwt)
-        return AuthenticationResponse(sessionToken: response.sessionToken, refreshToken: response.refreshToken, user: user, isFirstAuthentication: false)
+        return AuthenticationResponse(sessionToken: response.sessionToken, refreshToken: response.refreshToken, user: user, isFirstAuthentication: false, flowOutput: [:])
     }
 
     func revokeSessions(_ revoke: RevokeType, refreshJwt: String) async throws(DescopeError) {

--- a/ios/descope-swift-sdk/internal/routes/Shared.swift
+++ b/ios/descope-swift-sdk/internal/routes/Shared.swift
@@ -73,7 +73,7 @@ extension DescopeClient.JWTResponse {
         guard let sessionJwt, !sessionJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing session JWT") }
         guard let refreshJwt, !refreshJwt.isEmpty else { throw DescopeError.decodeError.with(message: "Missing refresh JWT") }
         guard let user else { throw DescopeError.decodeError.with(message: "Missing user details") }
-        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), user: user.convert(), isFirstAuthentication: firstSeen, externalToken: externalToken)
+        return try AuthenticationResponse(sessionToken: Token(jwt: sessionJwt), refreshToken: Token(jwt: refreshJwt), externalToken: externalToken, user: user.convert(), isFirstAuthentication: firstSeen ?? false, flowOutput: flowOutput ?? [:])
     }
 }
 

--- a/ios/descope-swift-sdk/sdk/SDK.swift
+++ b/ios/descope-swift-sdk/sdk/SDK.swift
@@ -147,7 +147,7 @@ public extension DescopeSDK {
     static let name = "DescopeKit"
     
     /// The Descope SDK version
-    static let version = "0.11.1"
+    static let version = "0.11.2"
 }
 
 // Internal

--- a/ios/descope-swift-sdk/types/Responses.swift
+++ b/ios/descope-swift-sdk/types/Responses.swift
@@ -5,12 +5,13 @@ import UIKit
 #endif
 
 /// Returned from user authentication calls.
-public struct AuthenticationResponse: Sendable {
+public struct AuthenticationResponse: @unchecked Sendable {
     public var sessionToken: DescopeToken
     public var refreshToken: DescopeToken
+    public var externalToken: String?
     public var user: DescopeUser
     public var isFirstAuthentication: Bool
-    public var externalToken: String?
+    public var flowOutput: [String: Any]
 }
 
 /// Returned from the ``DescopeAuth/refreshSession(refreshJwt:)`` call.

--- a/src/components/FlowView.tsx
+++ b/src/components/FlowView.tsx
@@ -1,9 +1,8 @@
-import type { JWTResponse } from '@descope/core-js-sdk'
 import React, { useCallback, useMemo, type SyntheticEvent } from 'react'
 import { requireNativeComponent, type HostComponent, type ViewStyle } from 'react-native'
 import { version } from '../../package.json'
 import useDescopeContext from '../internal/hooks/useContext'
-import type { DescopeError, FlowOptions } from '../types'
+import type { DescopeError, FlowJwtResponse, FlowOptions } from '../types'
 
 type FlowSession = {
   sessionJwt: string
@@ -82,7 +81,7 @@ const DescopeFlowView = requireNativeComponent('DescopeFlowView') as HostCompone
  * a set of callbacks when the Flow is `ready` to be presented, and finished in a `success` or `error` state.
  * @returns The Descope FlowView component
  */
-export default function FlowView(props: { flowOptions: FlowOptions; deepLink?: string; style?: ViewStyle; onReady?: () => unknown; onSuccess?: (jwtResponse: JWTResponse) => unknown; onError?: (error: DescopeError) => unknown }) {
+export default function FlowView(props: { flowOptions: FlowOptions; deepLink?: string; style?: ViewStyle; onReady?: () => unknown; onSuccess?: (jwtResponse: FlowJwtResponse) => unknown; onError?: (error: DescopeError) => unknown }) {
   const { onReady, onSuccess, onError } = props
   const { session, isSessionLoading } = useDescopeContext()
 
@@ -91,7 +90,10 @@ export default function FlowView(props: { flowOptions: FlowOptions; deepLink?: s
   const onSuccessHook = useCallback(
     (event: SyntheticEvent<never, { response: string }>) => {
       const rawResponse = JSON.parse(event.nativeEvent.response)
-      const jwtResponse = rawResponse as JWTResponse
+      // Both platforms omit the flow output when the flow doesn't set one. Android sends it as an
+      // object, while iOS encodes it as a JSON string, as the swift SDK does for its own Codable.
+      const flowOutput = typeof rawResponse.flowOutput === 'string' ? JSON.parse(rawResponse.flowOutput) : (rawResponse.flowOutput ?? {})
+      const jwtResponse = { ...rawResponse, flowOutput } as FlowJwtResponse
       // For authenticated flows - the session tokens from the current active session are used to authenticate
       // the user inside the flow, while the user object itself is unaffected. However, since the user is an integral
       // part of the session construct, a placeholder user is used by the native layer. When a flow finishes without

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,4 +9,4 @@ export { default as useFlow } from './hooks/useFlow'
 
 export { getCurrentSessionToken, getCurrentRefreshToken, getCurrentUser } from './helpers'
 
-export type { DescopeSession, DescopeSessionManager, DescopeFlow, DescopePasskey, FlowOptions, DescopeError } from './types'
+export type { DescopeSession, DescopeSessionManager, DescopeFlow, DescopePasskey, FlowOptions, FlowOutput, FlowJwtResponse, DescopeError } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,16 @@ export type DescopeError = {
   errorMessage?: string
 }
 
+/**
+ * Custom data returned from a flow's output, when running a flow that sets it.
+ *
+ * This is always empty for authentications that don't originate from a flow.
+ */
+export type FlowOutput = Record<string, unknown>
+
+/** The `JWTResponse` a flow finishes with, alongside any custom data set by the flow's output. */
+export type FlowJwtResponse = JWTResponse & { flowOutput: FlowOutput }
+
 /** Provide authentication info if the flow is being run by a user that's already authenticated. */
 export type FlowAuthentication = {
   /** The ID of the flow about to be run. */

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -40,10 +40,15 @@ describe('hooks', () => {
   })
 
   describe('FlowView', () => {
-    const renderWithContext = (overrides: Partial<DescopeContext>) => {
+    const renderWithContext = (overrides: Partial<DescopeContext>, props: Partial<React.ComponentProps<typeof FlowView>> = {}) => {
       const value: DescopeContext = { projectId, setSession: () => {}, isSessionLoading: false, ...overrides }
       const ctxWrapper = ({ children }: { children: React.ReactNode }) => React.createElement(Context.Provider, { value }, children)
-      return render(React.createElement(FlowView, { flowOptions: { url: 'https://example.com/flow' } }), { wrapper: ctxWrapper })
+      return render(React.createElement(FlowView, { flowOptions: { url: 'https://example.com/flow' }, ...props }), { wrapper: ctxWrapper })
+    }
+
+    const finishFlow = (response: Record<string, unknown>, onSuccess: jest.Mock) => {
+      const tree = renderWithContext({}, { onSuccess }).toJSON() as { props: { onFlowSuccess: (event: unknown) => void } }
+      tree.props.onFlowSuccess({ nativeEvent: { response: JSON.stringify(response) } })
     }
 
     it('defers rendering the native view while the persisted session is loading', () => {
@@ -59,6 +64,26 @@ describe('hooks', () => {
     it('does not pass session to the native view when no session exists', () => {
       const tree = renderWithContext({ session: undefined }).toJSON() as { props: { session?: unknown } } | null
       expect(tree?.props.session).toBeUndefined()
+    })
+
+    const flowOutput = { key: 'value', count: 3, nested: { inner: true } }
+
+    it('passes the flow output through when it arrives as an object', () => {
+      const onSuccess = jest.fn()
+      finishFlow({ sessionJwt: 'abc', refreshJwt: 'def', flowOutput }, onSuccess)
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ flowOutput }))
+    })
+
+    it('parses the flow output when it arrives as a JSON string', () => {
+      const onSuccess = jest.fn()
+      finishFlow({ sessionJwt: 'abc', refreshJwt: 'def', flowOutput: JSON.stringify(flowOutput) }, onSuccess)
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ flowOutput }))
+    })
+
+    it('defaults the flow output to an empty object when the flow sets none', () => {
+      const onSuccess = jest.fn()
+      finishFlow({ sessionJwt: 'abc', refreshJwt: 'def' }, onSuccess)
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ flowOutput: {} }))
     })
   })
 


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16932

## Description

- Expose `flowOutput` on the response a flow finishes with, set from the flow's output and empty otherwise
- Export the `FlowOutput` and `FlowJwtResponse` types

### Updated SDKs
- descope-swift `0.11.2`
- descope-kotlin `0.20.0`

## Must
- [x] Tests
- [x] Documentation (if applicable)