### PR TITLE
feat: opt-in sendSessionToken flow option to expose session JWT claims to flows

### DIFF
--- a/android/src/main/java/com/descope/android/DescopeFlow.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlow.kt
@@ -73,6 +73,16 @@ class DescopeFlow {
     var sessionProvider: (() -> DescopeSession?)? = null
 
     /**
+     * Whether to send the current session JWT on flow start/next requests, exposing
+     * its validated claims to the flow via the `sessionJwtClaims` context key
+     * (e.g. checking the `su` step-up claim). Off by default.
+     *
+     * The session is taken from the [sessionProvider] or the SDK's session manager,
+     * same as for authenticated flows.
+     */
+    var sendSessionToken: Boolean = false
+
+    /**
      * The ID of the oauth provider that is configured to natively "Sign In with Google".
      * Will likely be "google" if the Descope "Google" provider was customized,
      * or alternatively a custom provider ID.

--- a/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -196,6 +196,8 @@ class DescopeFlowCoordinator(val webView: WebView) {
         val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
+        val sessionJwt = if (flow.sendSessionToken) currentSession?.sessionJwt ?: "" else ""
+
         val nativeOptions = JSONObject().apply {
             put("platform", "android")
             put("bridgeVersion", 1)
@@ -205,6 +207,8 @@ class DescopeFlowCoordinator(val webView: WebView) {
             put("externalAuthRedirect", externalAuthRedirect)
             put("magicLinkRedirect", magicLinkRedirect)
             put("origin", origin)
+            // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it)
+            if (sessionJwt.isNotEmpty()) put("sessionJwt", sessionJwt)
         }
 
         var clientInputs = ""

--- a/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
+++ b/android/src/main/java/com/descope/android/DescopeFlowCoordinator.kt
@@ -189,14 +189,16 @@ class DescopeFlowCoordinator(val webView: WebView) {
             ""
         }
 
-        val refreshJwt = currentSession?.refreshJwt ?: ""
+        // take one session snapshot so refreshJwt and sessionJwt can't come from different sessions
+        val session = currentSession
+        val refreshJwt = session?.refreshJwt ?: ""
         val oauthProvider = flow.oauthNativeProvider?.name ?: ""
         val oauthRedirect = pickRedirectUrl(flow.oauthRedirect, flow.oauthRedirectCustomScheme, useCustomSchemeFallback)
         val ssoRedirect = pickRedirectUrl(flow.ssoRedirect, flow.ssoRedirectCustomScheme, useCustomSchemeFallback)
         val externalAuthRedirect = pickRedirectUrl(flow.externalAuthRedirect, flow.externalAuthRedirectCustomScheme, useCustomSchemeFallback)
         val magicLinkRedirect = flow.magicLinkRedirect ?: ""
 
-        val sessionJwt = if (flow.sendSessionToken) currentSession?.sessionJwt ?: "" else ""
+        val sessionJwt = if (flow.sendSessionToken && session != null && !session.sessionToken.isExpired) session.sessionJwt else ""
 
         val nativeOptions = JSONObject().apply {
             put("platform", "android")

--- a/android/src/main/java/com/descopereactnative/DescopeFlowViewManager.kt
+++ b/android/src/main/java/com/descopereactnative/DescopeFlowViewManager.kt
@@ -76,6 +76,9 @@ class DescopeFlowViewManager() : SimpleViewManager<DescopeFlowView>(), DescopeFl
       src.forEach { (k, v) -> v?.let { target[k] = it } }
       descopeFlow.clientInputs = target
     }
+    if (options.hasKey("sendSessionToken")) {
+      descopeFlow.sendSessionToken = options.getBoolean("sendSessionToken")
+    }
     descopeFlow.hooks = listOf(
             runJavaScript(DescopeFlowHook.Event.Loaded, """
                 window.descopeBridge.hostInfo.sdkName = 'reactnative'

--- a/ios/DescopeFlowViewManager.swift
+++ b/ios/DescopeFlowViewManager.swift
@@ -54,6 +54,9 @@ class DescopeFlowViewWrapper: DescopeFlowView, DescopeFlowViewDelegate {
         if let clientInputs = options["clientInputs"] as? [String: Any] {
             descopeFlow.clientInputs = clientInputs
         }
+        if let sendSessionToken = options["sendSessionToken"] as? Bool {
+            descopeFlow.sendSessionToken = sendSessionToken
+        }
         descopeFlow.hooks = [
             .runJavaScript(on: .loaded, code: """
                 window.descopeBridge.hostInfo.sdkName = 'reactnative'

--- a/ios/descope-swift-sdk/flows/Flow.swift
+++ b/ios/descope-swift-sdk/flows/Flow.swift
@@ -147,6 +147,14 @@ public class DescopeFlow {
     ///     This is especially important for projects that use refresh token rotation.
     public var sessionProvider: (() -> DescopeSession?)?
 
+    /// Whether to send the current session JWT on flow start/next requests, exposing
+    /// its validated claims to the flow via the `sessionJwtClaims` context key
+    /// (e.g. checking the `su` step-up claim). Off by default.
+    ///
+    /// The session is taken from the ``sessionProvider`` or the SDK's session manager,
+    /// same as for authenticated flows.
+    public var sendSessionToken: Bool = false
+
     /// Creates a new ``DescopeFlow`` object that encapsulates a single flow run.
     ///
     /// - Parameter url: The URL where the flow is hosted.

--- a/ios/descope-swift-sdk/flows/FlowBridge.swift
+++ b/ios/descope-swift-sdk/flows/FlowBridge.swift
@@ -146,6 +146,12 @@ extension FlowBridge {
             logger.info("Passing refreshJwt to flow initialization", session.refreshJwt)
             refreshJwt = session.refreshJwt
         }
+
+        // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it)
+        if flow.sendSessionToken, let session = flow.providedSession {
+            logger.info("Passing sessionJwt to flow initialization")
+            nativeOptions.sessionJwt = session.sessionJwt
+        }
         
         var clientInputs = ""
         if !flow.clientInputs.isEmpty {
@@ -451,6 +457,7 @@ private struct FlowNativeOptions: Encodable {
     var ssoRedirect = WebAuth.redirectURL
     var externalAuthRedirect = WebAuth.redirectURL
     var magicLinkRedirect = ""
+    var sessionJwt: String?
 
     var payload: String {
         guard let data = try? JSONEncoder().encode(self), let value = String(bytes: data, encoding: .utf8) else { return "{}" }

--- a/ios/descope-swift-sdk/flows/FlowBridge.swift
+++ b/ios/descope-swift-sdk/flows/FlowBridge.swift
@@ -147,8 +147,9 @@ extension FlowBridge {
             refreshJwt = session.refreshJwt
         }
 
-        // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it)
-        if flow.sendSessionToken, let session = flow.providedSession {
+        // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it);
+        // an expired session token is skipped so the flow never sees stale claims
+        if flow.sendSessionToken, let session = flow.providedSession, !session.sessionToken.isExpired {
             logger.info("Passing sessionJwt to flow initialization")
             nativeOptions.sessionJwt = session.sessionJwt
         }

--- a/ios/descope-swift-sdk/flows/FlowBridge.swift
+++ b/ios/descope-swift-sdk/flows/FlowBridge.swift
@@ -141,15 +141,18 @@ extension FlowBridge {
         nativeOptions.oauthProvider = flow.oauthNativeProvider?.name ?? ""
         nativeOptions.magicLinkRedirect = flow.magicLinkRedirect ?? ""
 
+        // take one session snapshot so refreshJwt and sessionJwt can't come from different sessions
+        let session = flow.providedSession
+
         var refreshJwt = ""
-        if let session = flow.providedSession {
+        if let session {
             logger.info("Passing refreshJwt to flow initialization", session.refreshJwt)
             refreshJwt = session.refreshJwt
         }
 
         // only sent when the host app opted in via sendSessionToken (bridge v4+ web components use it);
         // an expired session token is skipped so the flow never sees stale claims
-        if flow.sendSessionToken, let session = flow.providedSession, !session.sessionToken.isExpired {
+        if flow.sendSessionToken, let session, !session.sessionToken.isExpired {
             logger.info("Passing sessionJwt to flow initialization")
             nativeOptions.sessionJwt = session.sessionJwt
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,14 @@ export type FlowOptions = {
   /** The URL where the flow is hosted */
   url: string
   /**
+   * Whether to send the current session JWT on flow start/next requests, exposing
+   * its validated claims to the flow via the `sessionJwtClaims` context key
+   * (e.g. checking the `su` step-up claim). Off by default.
+   *
+   * Requires the hosted flow page to run web component bridge v4 or later.
+   */
+  sendSessionToken?: boolean
+  /**
    * The ID of the oauth provider that is configured to natively "Sign In with Google".
    * Will likely be "google" if the Descope "Google" provider was customized,
    * or alternatively a custom provider ID.


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17811

## Related PRs
### Upstream PRs
- https://github.com/descope/descope-js/pull/1473 (web component bridge v4)
- https://github.com/descope/descope-kotlin/pull/356
- https://github.com/descope/descope-swift/pull/155

## In a Nutshell
- New `FlowOptions.sendSessionToken` (off by default)
- Wired through the Android/iOS view managers to the native `DescopeFlow.sendSessionToken`
- Vendored native SDK sources patched with the same change as the upstream PRs

## Description
When enabled, the flow web component (bridge v4+) sends the current session JWT on flow start/next requests, so a flow can check the validated session claims server side - for example whether the user already completed step-up - via the `sessionJwtClaims` flow context key. The session used is the same one already passed for authenticated flows. The vendored `com/descope` and `descope-swift-sdk` sources carry the identical patch as the upstream native SDK PRs, so a future `update-*-sdk.sh` sync converges to the same content.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)